### PR TITLE
feat: add global error handling and account activation checks

### DIFF
--- a/apps/frontend/nuxt.config.ts
+++ b/apps/frontend/nuxt.config.ts
@@ -17,7 +17,8 @@ export default defineNuxtConfig({
     },
   },
   plugins: [
-    '~/plugins/websocket.ts'
+    '~/plugins/websocket.ts',
+    '~/plugins/error.ts',
   ],
   extends: [
     "@cortex/shared"

--- a/apps/frontend/src/components/auth/OAuthProfileForm.vue
+++ b/apps/frontend/src/components/auth/OAuthProfileForm.vue
@@ -131,20 +131,20 @@ const fieldGroups = computed(() => {
 
   // Personal info group
   groups.push({
-    title: 'Personal Information',
-    fields: fields.filter(f => ['first_name', 'last_name', 'username'].includes(f))
+    title: 'Información Personal',
+    fields: fields.filter(f => ['firstName', 'lastName', 'username'].includes(f))
   })
 
   // Additional info group  
   groups.push({
-    title: 'Additional Information',
-    fields: fields.filter(f => ['date_of_birth', 'country_code', 'gender'].includes(f))
+    title: 'Información Adicional',
+    fields: fields.filter(f => ['dateOfBirth', 'countryCode', 'gender'].includes(f))
   })
 
   // Password group (if needed)
   if (props.needsPassword) {
     groups.push({
-      title: 'Set Password',
+      title: 'Contraseña',
       fields: fields.filter(f => ['password', 'confirm_password'].includes(f))
     })
   }
@@ -174,8 +174,9 @@ const fieldGroups = computed(() => {
               v-for="group in fieldGroups" :key="group.title"
               class="bg-white bg-opacity-50 rounded-lg p-4 space-y-4">
             <h3 class="text-lg font-semibold text-purple-900 mb-4">{{ group.title }}</h3>
-            <div class="grid gap-4"
-                 :class="group.fields.length > 2 ? 'grid-cols-1' : 'grid-cols-2'">
+            <div
+                class="grid gap-4"
+                :class="group.fields.length > 2 ? 'grid-cols-1' : 'grid-cols-2'">
               <FormField
                   v-for="field in group.fields"
                   v-slot="{ componentField, errors }"
@@ -230,6 +231,7 @@ const fieldGroups = computed(() => {
                           :type="field.includes('password') ? 'password' : 'text'"
                           :placeholder="getFieldLabel(field)"
                           v-bind="componentField"
+                          autocomplete="new-password"
                           :class="{'border-red-500': errors.length}"
                       />
                     </template>

--- a/apps/frontend/src/composables/useProfileCompletion.ts
+++ b/apps/frontend/src/composables/useProfileCompletion.ts
@@ -1,0 +1,191 @@
+import {API_ROUTES} from '@cortex/shared/config/api'
+import {createFormDataFromProfile} from '~/utils/form'
+import {AppError} from '@cortex/shared/types'
+import {
+  transformSessionToProfileRequest,
+  type UpdateProfileRequest,
+  type UserResponse
+} from "~/interfaces"
+import {useWebErrorHandler} from "~/composables/useWebErrorHandler"
+
+interface PasswordUpdateData {
+  password: string
+  confirm_password: string
+}
+
+interface ApiError {
+  response?: {
+    status?: number
+  }
+}
+
+export function useProfileCompletion() {
+  const router = useRouter()
+  const {data: session, getSession, token, signOut} = useAuth()
+  const errorHandler = useWebErrorHandler()
+  const loading = ref(false)
+
+  const needsProfileCompletion = computed(() => {
+    if (!session.value) return false
+    return !session.value.username ||
+        !session.value.first_name ||
+        !session.value.last_name ||
+        !session.value.date_of_birth ||
+        !session.value.country_code ||
+        !session.value.gender
+  })
+
+  const needsPassword = computed(() => {
+    if (!session.value) return false
+    return !session.value.has_password
+  })
+
+  const initialData = computed((): Partial<UpdateProfileRequest> => {
+    return transformSessionToProfileRequest(session.value)
+  })
+
+  const updatePassword = async (
+      formData: PasswordUpdateData,
+      currentToken: string
+  ) => {
+    try {
+      await $fetch(`${API_ROUTES.USER}/change-password`, {
+        method: 'PATCH',
+        headers: {
+          'Authorization': currentToken
+        },
+        body: {
+          current_password: null,
+          new_password: formData.password,
+          confirm_password: formData.confirm_password
+        }
+      })
+    } catch (err) {
+      const apiError = err as ApiError
+      throw new AppError('Error al actualizar la contraseña', {
+        statusCode: apiError.response?.status || 500,
+        data: {
+          context: 'updatePassword',
+          originalError: err
+        }
+      })
+    }
+  }
+
+  const updateProfile = async (formData: UpdateProfileRequest) => {
+    loading.value = true
+
+    try {
+      const currentToken = token.value
+      if (!currentToken) {
+        throw new AppError('No se encontró token de autenticación', {
+          statusCode: 401,
+          data: {context: 'tokenValidation'}
+        })
+      }
+
+      const headers: HeadersInit = {
+        'Authorization': currentToken
+      }
+
+      // Update password if needed
+      if (needsPassword.value && formData.password && formData.confirm_password) {
+        const passwordData: PasswordUpdateData = {
+          password: formData.password,
+          confirm_password: formData.confirm_password
+        }
+        await updatePassword(passwordData, currentToken)
+      }
+
+      // Update profile
+      const form = createFormDataFromProfile(formData)
+      for (const pair of form.entries()) {
+        console.log(`${pair[0]}: ${pair[1]}`)
+      }
+      const response = await $fetch<UserResponse>(API_ROUTES.USER_INFO, {
+        method: 'PATCH',
+        headers,
+        body: form
+      })
+
+      if (!response?.id) {
+        throw new AppError('No se recibió respuesta válida del servidor', {
+          statusCode: 500,
+          data: {context: 'profileUpdate', response}
+        })
+      }
+      await getSession()
+      await router.push('/')
+      return response
+
+    } catch (err) {
+      const apiError = err as ApiError
+      const isAuthError = apiError.response?.status === 401
+      const errorOptions = {
+        statusCode: apiError.response?.status || 500,
+        fatal: false,
+        data: {
+          context: 'updateProfile',
+          formData: {
+            ...formData,
+            password: undefined,
+            confirm_password: undefined
+          },
+          originalError: err
+        }
+      }
+
+      if (isAuthError) {
+        await signOut()
+        errorOptions.fatal = true
+      }
+
+      await errorHandler.handleError(
+          err instanceof AppError ? err : new AppError(
+              'Error actualizando el perfil',
+              errorOptions
+          )
+      )
+
+      throw err
+    } finally {
+      loading.value = false
+    }
+  }
+
+  const checkSession = async () => {
+    try {
+      if (!session.value) {
+        await getSession()
+      }
+
+      if (!needsProfileCompletion.value && !needsPassword.value) {
+        await router.push('/')
+      }
+    } catch (err) {
+      const apiError = err as ApiError
+      await errorHandler.handleError(new AppError(
+          'Error al verificar la sesión',
+          {
+            statusCode: apiError.response?.status || 500,
+            fatal: true,
+            data: {
+              context: 'checkSession',
+              originalError: err
+            }
+          }
+      ))
+      await signOut()
+    }
+  }
+
+  return {
+    loading,
+    session,
+    needsProfileCompletion,
+    needsPassword,
+    initialData,
+    updateProfile,
+    checkSession
+  }
+}

--- a/apps/frontend/src/composables/useWebErrorHandler.ts
+++ b/apps/frontend/src/composables/useWebErrorHandler.ts
@@ -1,0 +1,42 @@
+import type { ErrorHandler, ErrorOptions } from '@cortex/shared/types'
+import { AppError } from '@cortex/shared/types'
+import { useToast } from "@cortex/shared/components/ui/toast"
+
+export const useWebErrorHandler = (): ErrorHandler => {
+  const { toast } = useToast()
+
+  const handleError = async (err: unknown, options: ErrorOptions = {}) => {
+    if (err instanceof AppError && err.isHandled) {
+      return
+    }
+
+    const appError = err instanceof AppError
+        ? err
+        : new AppError(err instanceof Error ? err.message : String(err), options)
+
+    appError.isHandled = true
+
+    // Log error details to console in development
+    if (import.meta.dev) {
+      console.error(`Error details:`, {
+        message: appError.message,
+        statusCode: appError.statusCode,
+        data: appError.data || {},
+        stack: appError.stack || 'No stack trace available'
+      })
+    }
+
+    if (!options.silent) {
+      // Always show toast for both fatal and non-fatal errors
+      toast({
+        title: `Error ${appError.statusCode}`,
+        description: appError.message,
+        variant: 'destructive',
+      })
+    }
+  }
+
+  return {
+    handleError
+  }
+}

--- a/apps/frontend/src/interfaces/user.interface.ts
+++ b/apps/frontend/src/interfaces/user.interface.ts
@@ -3,6 +3,8 @@
  *
  * **/
 
+import {parseISO} from "date-fns";
+
 /**
  * Represents a User entity.
  * It contains basic user information like username, email, roles, and providers.
@@ -108,16 +110,30 @@ export const transformSessionToProfileRequest = (sessionData: any): UpdateProfil
     throw new Error('No session data provided')
   }
 
-  const transformedData: UpdateProfileRequest = {
-    username: sessionData.username || '',
-    first_name: sessionData.first_name || '',
-    last_name: sessionData.last_name || '',
-    email: sessionData.email || '',
-    date_of_birth: sessionData.date_of_birth ? new Date(sessionData.date_of_birth) : new Date(),
-    country_code: sessionData.country_code || '',
-    gender: sessionData.gender || 'PREFER_NOT_TO_SAY',
+
+  let dateOfBirth: Date | undefined
+
+  if (sessionData.date_of_birth) {
+    try {
+      if (typeof sessionData.date_of_birth === 'string') {
+        dateOfBirth = parseISO(sessionData.date_of_birth)
+      }
+      else if (sessionData.date_of_birth instanceof Date) {
+        dateOfBirth = sessionData.date_of_birth
+      }
+    } catch (error) {
+      console.error('Error parsing date of birth:', error)
+      dateOfBirth = undefined
+    }
   }
 
-  console.log('Transformed session data:', transformedData)
-  return transformedData
+  return {
+    username: sessionData.username || '',
+    firstName: sessionData.first_name,
+    lastName: sessionData.last_name,
+    email: sessionData.email || '',
+    dateOfBirth: dateOfBirth,
+    countryCode: sessionData.country_code,
+    gender: sessionData.gender || 'PREFER_NOT_TO_SAY',
+  }
 }

--- a/apps/frontend/src/pages/auth/callback.vue
+++ b/apps/frontend/src/pages/auth/callback.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { ref, onMounted } from 'vue'
 import { useAuthStore } from "~/stores"
+import {AppError} from "@cortex/shared/types";
 
 definePageMeta({
   auth: {
@@ -17,17 +18,18 @@ onMounted(async () => {
   const token = urlParams.get('token')
 
   try {
-    if (token) {
-      const redirectTo = await authStore.handleOAuthCallback(token)
-      message.value = 'Autenticación exitosa. Redirigiendo...'
-      setTimeout(() => router.push(redirectTo), 1500) 
-    } else {
-      throw new Error('No se recibió token de autenticación')
+
+    if(!token) {
+      throw new AppError('Token no encontrado')
     }
-  } catch (error) {
-    console.error('Error en la autenticación:', error)
+    const redirectTo = await authStore.handleOAuthCallback(token!)
+    message.value = 'Autenticación exitosa. Redirigiendo...'
+    await nextTick()
+    await router.replace(redirectTo)
+  } catch (err) {
     message.value = 'Error en la autenticación. Redirigiendo al login...'
-    setTimeout(() => router.push('/auth/login'), 1500)
+    await nextTick()
+    await router.replace('/auth/login')
   }
 })
 </script>

--- a/apps/frontend/src/pages/auth/complete-profile.vue
+++ b/apps/frontend/src/pages/auth/complete-profile.vue
@@ -1,105 +1,38 @@
 <script setup lang="ts">
-import { API_ROUTES } from '~/config/api'
 import OAuthProfileForm from "~/components/auth/OAuthProfileForm.vue"
-import { createFormDataFromProfile } from '~/utils/form'
-import {
-  transformSessionToProfileRequest,
-  type UpdateProfileRequest,
-  type UserResponse
-} from "~/interfaces"
+import type {UpdateProfileRequest} from "~/interfaces"
+import {useProfileCompletion} from "~/composables/useProfileCompletion";
 
-const router = useRouter()
-const { data: session, getSession, token, signOut } = useAuth()
-const loading = ref(false)
-const error = ref('')
+const {
+  loading,
+  needsProfileCompletion,
+  needsPassword,
+  initialData,
+  updateProfile,
+  checkSession
+} = useProfileCompletion()
 
-const needsProfileCompletion = computed(() => {
-  if (!session.value) return false
-  return !session.value.username ||
-      !session.value.first_name ||
-      !session.value.last_name ||
-      !session.value.date_of_birth ||
-      !session.value.country_code ||
-      !session.value.gender
-})
+onMounted(checkSession)
 
-const needsPassword = computed(() => {
-  if (!session.value) return false
-  return !session.value.has_password
-})
-
-const initialData = computed((): Partial<UpdateProfileRequest> => {
-  return transformSessionToProfileRequest(session.value)
-})
 
 const handleSubmit = async (formData: UpdateProfileRequest) => {
-  loading.value = true
-  error.value = ''
-
   try {
-    const currentToken = token.value
-    if (!currentToken) {
-      throw new Error('No se encontró token de autenticación')
+    if (!formData) {
+      console.error('No form data provided')
+      return
     }
 
-    const headers: HeadersInit = {
-      'Authorization': currentToken
-    }
-
-    if (needsPassword.value && formData.password) {
-      await $fetch(`${API_ROUTES.USER}/change-password`, {
-        method: 'PATCH',
-        headers,
-        body: {
-          current_password: null,
-          new_password: formData.password,
-          confirm_password: formData.confirm_password
-        }
-      })
-    }
-
-    const form = createFormDataFromProfile(formData)
-
-    const response = await $fetch<UserResponse>(API_ROUTES.USER_INFO, {
-      method: 'PATCH',
-      headers,
-      body: form
+    console.log('Submitting form data:', {
+      ...formData,
+      password: formData.password ? '[REDACTED]' : undefined,
+      confirm_password: formData.confirm_password ? '[REDACTED]' : undefined
     })
 
-    console.log('Profile updated:', response)
-    await getSession()
-
-    if (response?.id) {
-      await router.push('/')
-    } else {
-      throw new Error('No se recibió respuesta válida del servidor')
-    }
-  } catch (err) {
-    console.error('Error updating profile:', err)
-    error.value = err instanceof Error ? err.message : 'Error actualizando el perfil'
-
-    if (err.response?.status === 401) {
-      await signOut()
-    }
-  } finally {
-    loading.value = false
+    await updateProfile(formData)
+  } catch (error) {
+    console.error('Error submitting form:', error)
   }
 }
-
-onMounted(async () => {
-  try {
-    if (!session.value) {
-      await getSession()
-    }
-
-    if (!needsProfileCompletion.value && !needsPassword.value) {
-      await router.push('/')
-    }
-  } catch (err) {
-    console.error('Session error:', err)
-    await signOut()
-  }
-})
 </script>
 
 <template>
@@ -112,9 +45,5 @@ onMounted(async () => {
           @submit="handleSubmit"
       />
     </template>
-    <Alert v-if="error" variant="destructive" class="mt-4">
-      <AlertTitle>Error</AlertTitle>
-      <AlertDescription>{{ error }}</AlertDescription>
-    </Alert>
   </div>
 </template>

--- a/apps/frontend/src/plugins/error.ts
+++ b/apps/frontend/src/plugins/error.ts
@@ -1,0 +1,139 @@
+import { useWebErrorHandler } from "~/composables/useWebErrorHandler"
+import { AppError } from "@cortex/shared/types"
+
+export default defineNuxtPlugin((nuxtApp) => {
+  const errorHandler = useWebErrorHandler()
+
+  /**
+   * Determines if an error is a fatal error in the web context
+   * @param error - The error object to evaluate
+   * @param info - Additional Vue error information
+   * @returns boolean indicating if the error is fatal
+   */
+  const isFatalError = (error: unknown, info?: string): boolean => {
+    if (error instanceof Error) {
+      const conditions = [
+        error.message.includes('fetch'),   // Network/API errors
+        error.message.includes('auth'),    // Authentication errors
+        info?.includes('render'),          // Vue rendering errors
+        info?.includes('setup'),           // Vue component setup errors
+        error.message.includes('fatal'),   // Explicitly marked fatal errors
+        true,        // Type errors that could break the app
+        error.message.includes('undefined is not a function'), // Common fatal JS errors
+      ]
+      return conditions.some(condition => condition)
+    }
+    return false
+  }
+
+  /**
+   * Global Vue error handler
+   */
+  nuxtApp.vueApp.config.errorHandler = async (error, instance, info) => {
+    if (error instanceof AppError && error.isHandled) {
+      return
+    }
+
+    const errorMessage = error instanceof Error ? error.message : String(error)
+
+    if (import.meta.dev) {
+      console.debug(`Vue error intercepted: ${errorMessage}`, {
+        component: instance?.$options?.name || 'unknown',
+        info: info || 'no info provided',
+        errorType: error instanceof Error ? error.constructor.name : typeof error
+      })
+    }
+
+    const fatal = isFatalError(error, info)
+
+    await errorHandler.handleError(error, {
+      fatal,
+      statusCode: fatal ? 500 : 400,
+      data: {
+        component: instance?.$options?.name,
+        errorInfo: info,
+        isNetworkError: error instanceof Error && (
+            error.message.includes('fetch') ||
+            error.message.includes('network')
+        ),
+        vueInfo: {
+          lifecycle: info,
+          componentName: instance?.$options?.name,
+          componentPath: instance?.$options?.__file,
+        }
+      }
+    })
+  }
+
+  if (import.meta.client) {
+    /**
+     * Handle unhandled promise rejections
+     */
+    window.addEventListener('unhandledrejection', async (event) => {
+      if (event.reason instanceof AppError && event.reason.isHandled) {
+        return
+      }
+
+      const errorMessage = event.reason?.message || 'Unknown rejection reason'
+
+      if (import.meta.dev) {
+        console.debug(`Unhandled rejection intercepted: ${errorMessage}`, {
+          type: 'unhandledRejection',
+          errorType: event.reason?.constructor.name || 'Unknown',
+          stack: event.reason?.stack || 'No stack trace available'
+        })
+      }
+
+      await errorHandler.handleError(event.reason, {
+        fatal: true,
+        statusCode: 500,
+        data: {
+          type: 'unhandledRejection',
+          promise: {
+            state: 'rejected',
+            reason: event.reason
+          }
+        }
+      })
+    })
+
+    /**
+     * Handle general JavaScript errors
+     */
+    window.addEventListener('error', async (event) => {
+      if (event.error instanceof AppError && event.error.isHandled) {
+        return
+      }
+
+      if (import.meta.dev) {
+        console.debug(`Global error intercepted:`, {
+          message: event.message,
+          filename: event.filename,
+          lineno: event.lineno,
+          colno: event.colno,
+          error: event.error
+        })
+      }
+
+      await errorHandler.handleError(event.error || event.message, {
+        fatal: true,
+        statusCode: 500,
+        data: {
+          type: 'globalError',
+          source: {
+            filename: event.filename,
+            line: event.lineno,
+            column: event.colno
+          }
+        }
+      })
+    })
+  }
+
+  // Provide the error handler to be used throughout the app
+  return {
+    provide: {
+      errorHandler
+    }
+  }
+})

--- a/apps/frontend/src/stores/auth.store.ts
+++ b/apps/frontend/src/stores/auth.store.ts
@@ -1,8 +1,10 @@
-import {API_ROUTES} from "@cortex/shared/config/api";
+import { API_ROUTES } from "@cortex/shared/config/api"
+import { AppError } from '@cortex/shared/types'
 
 export const useAuthStore = defineStore('auth', () => {
   const { getSession } = useAuth()
   const { setToken } = useAuthState()
+  const { handleError } = useWebErrorHandler()
   const loading = ref(false)
 
   const handleOAuthCallback = async (token: string) => {
@@ -13,13 +15,13 @@ export const useAuthStore = defineStore('auth', () => {
 
       if (session) {
         const needsPassword = !session.has_password
-        
+
 
         if (needsPassword) {
           return '/auth/complete-profile'
         }
       }
-      
+
       return '/roadmaps'
     } catch (error) {
       console.error('OAuth callback error:', error)
@@ -29,6 +31,7 @@ export const useAuthStore = defineStore('auth', () => {
     }
   }
 
+
   const loginWithProvider = (provider: 'github' | 'google') => {
     window.location.href = `${API_ROUTES.OAUTH_BASE}/${provider}`
   }
@@ -36,13 +39,34 @@ export const useAuthStore = defineStore('auth', () => {
   const activateAccount = async (token: string) => {
     try {
       loading.value = true
+
+      if (!token) {
+        throw new AppError('Token de activación no proporcionado', {
+          statusCode: 400,
+          data: { context: 'accountActivation' }
+        })
+      }
+
       await $fetch(`${API_ROUTES.ACTIVATE_ACCOUNT}/auth/activate-account`, {
         method: 'GET',
         params: { token }
       })
-    } catch (error) {
-      console.error('Account activation error:', error)
-      throw error
+    } catch (err: unknown) {
+      if (err instanceof AppError) {
+        await handleError(err)
+      } else {
+        await handleError(new AppError(
+            'Error en la activación de la cuenta',
+            {
+              statusCode: 400,
+              data: {
+                context: 'accountActivation',
+                originalError: err
+              }
+            }
+        ))
+      }
+      throw err
     } finally {
       loading.value = false
     }


### PR DESCRIPTION
Add a new error handling plugin to manage application errors globally. 
Enhance the account activation process by validating the token and improving error handling for better user feedback. Include necessary imports and update the configuration to include the new error plugin.