### PR TITLE
update-roadmap-mappers-and-dtos

### DIFF
--- a/apps/backend/education/src/main/java/com/cortex/backend/education/roadmap/api/dto/RoadmapCourseDTO.java
+++ b/apps/backend/education/src/main/java/com/cortex/backend/education/roadmap/api/dto/RoadmapCourseDTO.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import java.io.Serial;
 import java.io.Serializable;
-import java.time.LocalDateTime;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -12,17 +11,17 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+
 @Getter
 @Setter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class RoadmapDetails implements Serializable {
+public class RoadmapCourseDTO implements Serializable {
     @Serial
     private static final long serialVersionUID = 1L;
-
     private Long id;
-    private String title;
+    private String name;
     private String description;
 
     @JsonProperty("image_url")
@@ -31,15 +30,5 @@ public class RoadmapDetails implements Serializable {
 
     @JsonProperty("tag_names")
     private List<String> tagNames;
-
-    private List<RoadmapCourseDTO> courses;
-
-    @JsonProperty("is_published")
-    private boolean isPublished;
-
-    @JsonProperty("created_at")
-    private LocalDateTime createdAt;
-
-    @JsonProperty("updated_at")
-    private LocalDateTime updatedAt;
+    private List<RoadmapModuleDTO> modules;
 }

--- a/apps/backend/education/src/main/java/com/cortex/backend/education/roadmap/api/dto/RoadmapLessonDTO.java
+++ b/apps/backend/education/src/main/java/com/cortex/backend/education/roadmap/api/dto/RoadmapLessonDTO.java
@@ -1,0 +1,24 @@
+package com.cortex.backend.education.roadmap.api.dto;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import java.io.Serial;
+import java.io.Serializable;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class RoadmapLessonDTO implements Serializable {
+  @Serial
+  private static final long serialVersionUID = 1L;
+  private Long id;
+  private String name;
+  private String slug;
+  private Integer credits;
+}

--- a/apps/backend/education/src/main/java/com/cortex/backend/education/roadmap/api/dto/RoadmapModuleDTO.java
+++ b/apps/backend/education/src/main/java/com/cortex/backend/education/roadmap/api/dto/RoadmapModuleDTO.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import java.io.Serial;
 import java.io.Serializable;
-import java.time.LocalDateTime;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -17,29 +16,15 @@ import lombok.Setter;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class RoadmapDetails implements Serializable {
+public class RoadmapModuleDTO implements Serializable {
     @Serial
     private static final long serialVersionUID = 1L;
-
     private Long id;
-    private String title;
+    private String name;
     private String description;
-
-    @JsonProperty("image_url")
-    private String imageUrl;
     private String slug;
 
-    @JsonProperty("tag_names")
-    private List<String> tagNames;
-
-    private List<RoadmapCourseDTO> courses;
-
-    @JsonProperty("is_published")
-    private boolean isPublished;
-
-    @JsonProperty("created_at")
-    private LocalDateTime createdAt;
-
-    @JsonProperty("updated_at")
-    private LocalDateTime updatedAt;
+    @JsonProperty("lesson_count")
+    private int lessonCount;
+    private List<RoadmapLessonDTO> lessons;
 }

--- a/apps/backend/education/src/main/java/com/cortex/backend/education/roadmap/internal/RoadmapServiceImpl.java
+++ b/apps/backend/education/src/main/java/com/cortex/backend/education/roadmap/internal/RoadmapServiceImpl.java
@@ -28,6 +28,8 @@ import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -71,10 +73,12 @@ public class RoadmapServiceImpl implements RoadmapService {
 
   @Override
   @Transactional(readOnly = true)
+  @Cacheable(value = "roadmaps", key = "#slug")
   public Optional<RoadmapDetails> getRoadmapBySlug(String slug) {
     return roadmapRepository.findBySlug(slug)
         .map(roadmapMapper::toRoadmapDetails);
   }
+
 
   @Override
   @Transactional
@@ -86,6 +90,7 @@ public class RoadmapServiceImpl implements RoadmapService {
     return roadmapMapper.toRoadmapResponse(savedRoadmap);
   }
 
+  @CacheEvict(value = "roadmaps", key = "#id")
   @Override
   @Transactional
   public RoadmapResponse updateRoadmap(Long id, RoadmapUpdateRequest request) {


### PR DESCRIPTION
### Pull Request Description

This pull request implements several key updates to the roadmap-related data handling within our application, incorporating improvements in caching, data structures, and mappings.

#### Changes Included:
1. **Redis Cache Configuration**:
   - Refactored the Redis cache configuration to leverage a custom `ObjectMapper` for efficient serialization of values. 
   - Introduced specific Time-To-Live (TTL) settings for different cache types to optimize performance. This centralizes the `ObjectMapper` creation for consistent JSON mapping across the application.

2. **New Data Transfer Objects (DTOs)**:
   - Added new DTO classes: `RoadmapCourseDTO`, `RoadmapModuleDTO`, and `RoadmapLessonDTO`. These classes encapsulate data pertaining to various components of the roadmap structure, enhancing organization and serialization capabilities for related APIs.
   - Updated the `RoadmapDetails` to incorporate the newly introduced DTOs.

3. **Roadmap Mapper Enhancements**:
   - Refined the roadmap mapper to provide detailed API responses by renaming mapping methods and utilizing the DTOs. This improves the clarity and structure of the data returned, focusing specifically on providing comprehensive insights into educational resources.
   - Ensured that only published modules and lessons are included in the responses, thereby improving data relevance.

4. **Caching Implementation**:
   - Introduced caching mechanisms to enhance the efficiency of roadmap data retrieval and updates. The `getRoadmapBySlug` method is now annotated with `@Cacheable` to cache results based on the slug, while the `updateRoadmap` method uses `@CacheEvict` to clear cached entries upon updates. This change is expected to improve performance and decrease database load significantly.

These updates collectively aim to streamline the roadmap functionality, improve performance through caching, and enhance the clarity of data structures returned by the APIs. 

Please review the changes and provide feedback.