### PR TITLE
feat(api): update roadmap slug for programming intro

### DIFF
--- a/bruno/Education/Roadmap/Get Roadmap By Slug.bru
+++ b/bruno/Education/Roadmap/Get Roadmap By Slug.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 get {
-  url: {{BASEURL}}/api/v1/education/roadmap/slug/hamir-e-ignacio-en-locas-aventuras
+  url: {{BASEURL}}/api/v1/education/roadmap/introduccion-al-mundo-de-la-programacion
   body: none
   auth: bearer
 }


### PR DESCRIPTION
Changes the API URL for retrieving the roadmap to use the new slug 
that corresponds to the "Introducción al mundo de la programación" 
course, ensuring the endpoint reflects the correct educational 
content for users.