### PR TITLE
chore: upgrade tauri-plugin-oauth to version 2.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ serde = { version = "1.0", features = ["derive"] }
 log = "0.4.22"
 tauri = { version = "2.0.6", features = ["protocol-asset"] }
 tauri-plugin-shell = "2.0.2"
-tauri-plugin-oauth = { git = "https://github.com/FabianLars/tauri-plugin-oauth", branch = "v2" }
+tauri-plugin-oauth = "2"
 tauri-plugin-store = "2.1.0"
 reqwest = { version = "0.12.9", features = ["json"] }
 thiserror = "1.0.66"

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -19,7 +19,7 @@
     "@codemirror/state": "^6.4.1",
     "@codemirror/view": "^6.34.1",
     "@cortex/shared": "workspace:^",
-    "@fabianlars/tauri-plugin-oauth": "github:FabianLars/tauri-plugin-oauth#v2",
+    "@fabianlars/tauri-plugin-oauth": "^2.0.0",
     "@nuxt/image": "^1.8.1",
     "@tauri-apps/api": "^2.0.3",
     "@tauri-apps/plugin-clipboard-manager": "2.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,8 +84,8 @@ importers:
         specifier: workspace:^
         version: link:../../packages/shared
       '@fabianlars/tauri-plugin-oauth':
-        specifier: github:FabianLars/tauri-plugin-oauth#v2
-        version: https://codeload.github.com/FabianLars/tauri-plugin-oauth/tar.gz/9b5d78beb7ff9426765ba3597b4d6edb54d119e8
+        specifier: ^2.0.0
+        version: 2.0.0
       '@nuxt/image':
         specifier: ^1.8.1
         version: 1.8.1(ioredis@5.4.1)(magicast@0.3.5)(rollup@4.24.3)
@@ -1081,9 +1081,8 @@ packages:
     resolution: {integrity: sha512-CXtq5nR4Su+2I47WPOlWud98Y5Lv8Kyxp2ukhgFx/eW6Blm18VXJO5WuQylPugRo8nbluoi6GvvxBLqHcvqUUw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@fabianlars/tauri-plugin-oauth@https://codeload.github.com/FabianLars/tauri-plugin-oauth/tar.gz/9b5d78beb7ff9426765ba3597b4d6edb54d119e8':
-    resolution: {tarball: https://codeload.github.com/FabianLars/tauri-plugin-oauth/tar.gz/9b5d78beb7ff9426765ba3597b4d6edb54d119e8}
-    version: 0.1.0
+  '@fabianlars/tauri-plugin-oauth@2.0.0':
+    resolution: {integrity: sha512-I1s08ZXrsFuYfNWusAcpLyiCfr5TCvaBrRuKfTG+XQrcaqnAcwjdWH0U5J9QWuMDLwCUMnVxdobtMJzPR8raxQ==}
 
   '@fastify/accept-negotiator@1.1.0':
     resolution: {integrity: sha512-OIHZrb2ImZ7XG85HXOONLcJWGosv7sIvM2ifAPQVhg9Lv7qdmMBNVaai4QTdyuaqbKM5eO6sLSQOYI7wEQeCJQ==}
@@ -8076,7 +8075,7 @@ snapshots:
     dependencies:
       levn: 0.4.1
 
-  '@fabianlars/tauri-plugin-oauth@https://codeload.github.com/FabianLars/tauri-plugin-oauth/tar.gz/9b5d78beb7ff9426765ba3597b4d6edb54d119e8':
+  '@fabianlars/tauri-plugin-oauth@2.0.0':
     dependencies:
       '@tauri-apps/api': 2.0.3
 


### PR DESCRIPTION
Updates the dependency for `@fabianlars/tauri-plugin-oauth` from a specific 
GitHub tarball link to version 2.0.0 across multiple files, ensuring consistency in package resolution. This change improves maintainability 
by using a versioned release instead of a direct link to the repository.