### PR TITLE
feat(roadmap): Add user context to getRoadmapBySlug

### DIFF
--- a/apps/backend/education/src/main/java/com/cortex/backend/education/roadmap/api/RoadmapController.java
+++ b/apps/backend/education/src/main/java/com/cortex/backend/education/roadmap/api/RoadmapController.java
@@ -1,12 +1,12 @@
 package com.cortex.backend.education.roadmap.api;
 
 import com.cortex.backend.core.common.PageResponse;
+import com.cortex.backend.core.domain.User;
 import com.cortex.backend.education.course.api.dto.CourseResponse;
 import com.cortex.backend.education.roadmap.api.dto.RoadmapDetails;
 import com.cortex.backend.education.roadmap.api.dto.RoadmapRequest;
 import com.cortex.backend.education.roadmap.api.dto.RoadmapResponse;
 import com.cortex.backend.education.roadmap.api.dto.RoadmapUpdateRequest;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -14,12 +14,12 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.io.IOException;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -55,8 +55,11 @@ public class RoadmapController {
   @ApiResponse(responseCode = "200", description = "Successful operation",
       content = @Content(schema = @Schema(implementation = RoadmapResponse.class)))
   @ApiResponse(responseCode = "404", description = "Roadmap not found")
-  public ResponseEntity<RoadmapDetails> getRoadmapBySlug(@PathVariable String slug) {
-    return roadmapService.getRoadmapBySlug(slug)
+  public ResponseEntity<RoadmapDetails> getRoadmapBySlug(
+      @PathVariable String slug,
+      Authentication authentication) {
+    User user = (User) authentication.getPrincipal();
+    return roadmapService.getRoadmapBySlug(slug, user.getId())
         .map(ResponseEntity::ok)
         .orElse(ResponseEntity.notFound().build());
   }

--- a/apps/backend/education/src/main/java/com/cortex/backend/education/roadmap/api/RoadmapRepository.java
+++ b/apps/backend/education/src/main/java/com/cortex/backend/education/roadmap/api/RoadmapRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -21,4 +22,14 @@ public interface RoadmapRepository extends CrudRepository<Roadmap, Long> {
       WHERE rodmap.isPublished = true
       """)
   Page<Roadmap> findAllPublishedRoadmaps(Pageable pageable);
+
+  @Query("""
+    SELECT DISTINCT r FROM Roadmap r
+    LEFT JOIN FETCH r.courses c
+    LEFT JOIN FETCH c.moduleEntities m
+    LEFT JOIN FETCH m.lessons l
+    LEFT JOIN FETCH l.exercises e
+    WHERE r.slug = :slug AND r.isPublished = true
+    """)
+  Optional<Roadmap> findBySlugWithDetails(@Param("slug") String slug);
 }

--- a/apps/backend/education/src/main/java/com/cortex/backend/education/roadmap/api/RoadmapService.java
+++ b/apps/backend/education/src/main/java/com/cortex/backend/education/roadmap/api/RoadmapService.java
@@ -16,7 +16,7 @@ public interface RoadmapService {
 
   PageResponse<RoadmapResponse> getAllRoadmaps(int page, int size);
 
-  Optional<RoadmapDetails> getRoadmapBySlug(String slug);
+  Optional<RoadmapDetails> getRoadmapBySlug(String slug, Long userId);
 
   RoadmapResponse createRoadmap(RoadmapRequest request);
 

--- a/apps/backend/education/src/main/java/com/cortex/backend/education/roadmap/api/dto/RoadmapExerciseDTO.java
+++ b/apps/backend/education/src/main/java/com/cortex/backend/education/roadmap/api/dto/RoadmapExerciseDTO.java
@@ -1,9 +1,7 @@
 package com.cortex.backend.education.roadmap.api.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import java.io.Serial;
 import java.io.Serializable;
-import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -15,14 +13,13 @@ import lombok.Setter;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class RoadmapLessonDTO implements Serializable {
+public class RoadmapExerciseDTO implements Serializable {
   @Serial
   private static final long serialVersionUID = 1L;
-  private Long id;
-  private String name;
-  private String slug;
-  private Integer credits;
 
-  @JsonProperty("exercises")
-  private List<RoadmapExerciseDTO> exercises;
+  private Long id;
+  private String title;
+  private String slug;
+  private Integer points;
+  private boolean completed;
 }

--- a/apps/backend/education/src/main/java/com/cortex/backend/education/roadmap/internal/RoadmapMapper.java
+++ b/apps/backend/education/src/main/java/com/cortex/backend/education/roadmap/internal/RoadmapMapper.java
@@ -1,11 +1,15 @@
 package com.cortex.backend.education.roadmap.internal;
 
 import com.cortex.backend.core.domain.Course;
+import com.cortex.backend.core.domain.EntityType;
+import com.cortex.backend.core.domain.Exercise;
 import com.cortex.backend.core.domain.Lesson;
 import com.cortex.backend.core.domain.ModuleEntity;
 import com.cortex.backend.core.domain.Tag;
+import com.cortex.backend.education.progress.api.UserProgressService;
 import com.cortex.backend.education.roadmap.api.dto.RoadmapCourseDTO;
 import com.cortex.backend.education.roadmap.api.dto.RoadmapDetails;
+import com.cortex.backend.education.roadmap.api.dto.RoadmapExerciseDTO;
 import com.cortex.backend.education.roadmap.api.dto.RoadmapLessonDTO;
 import com.cortex.backend.education.roadmap.api.dto.RoadmapModuleDTO;
 import com.cortex.backend.education.roadmap.api.dto.RoadmapRequest;
@@ -15,6 +19,7 @@ import com.cortex.backend.core.domain.Media;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
+import org.mapstruct.Context;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.Named;
@@ -38,11 +43,11 @@ public interface RoadmapMapper {
   @Mapping(target = "slug", ignore = true)
   Roadmap toRoadmap(RoadmapRequest roadmapRequest);
 
-  @Mapping(target = "imageUrl", source = "image", qualifiedByName = "mediaToUrl")
-  @Mapping(target = "courses", source = "courses", qualifiedByName = "coursesToDetailedResponses")
-  @Mapping(target = "tagNames", source = "tags", qualifiedByName = "tagsToNamesList")
-  @Mapping(target = "isPublished", source = "published")
-  RoadmapDetails toRoadmapDetails(Roadmap roadmap);
+  @Mapping(target = "imageUrl", source = "roadmap.image", qualifiedByName = "mediaToUrl")
+  @Mapping(target = "courses", expression = "java(mapCourses(roadmap, userId, userProgressService))")
+  @Mapping(target = "tagNames", source = "roadmap.tags", qualifiedByName = "tagsToNamesList")
+  @Mapping(target = "isPublished", source = "roadmap.published")
+  RoadmapDetails toRoadmapDetails(Roadmap roadmap, @Context Long userId, @Context UserProgressService userProgressService);
 
   @Named("mediaToUrl")
   default String mediaToUrl(Media media) {
@@ -63,9 +68,8 @@ public interface RoadmapMapper {
         .collect(Collectors.toSet()) : null;
   }
 
-  @Named("coursesToDetailedResponses")
-  default List<RoadmapCourseDTO> coursesToDetailedResponses(Set<Course> courses) {
-    return courses != null ? courses.stream()
+  default List<RoadmapCourseDTO> mapCourses(Roadmap roadmap, Long userId, UserProgressService userProgressService) {
+    return roadmap.getCourses() != null ? roadmap.getCourses().stream()
         .map(course -> new RoadmapCourseDTO(
             course.getId(),
             course.getName(),
@@ -73,13 +77,14 @@ public interface RoadmapMapper {
             mediaToUrl(course.getImage()),
             course.getSlug(),
             tagsToNamesList(course.getTags()),
-            modulesToDetailedResponses(course.getModuleEntities())
+            modulesToDetailedResponses(course.getModuleEntities(), userId, userProgressService)
         ))
         .toList() : null;
   }
 
+
   @Named("modulesToDetailedResponses")
-  default List<RoadmapModuleDTO> modulesToDetailedResponses(Set<ModuleEntity> modules) {
+  default List<RoadmapModuleDTO> modulesToDetailedResponses(Set<ModuleEntity> modules, Long userId, UserProgressService userProgressService) {
     return modules != null ? modules.stream()
         .filter(ModuleEntity::getIsPublished)
         .map(module -> new RoadmapModuleDTO(
@@ -88,21 +93,35 @@ public interface RoadmapMapper {
             module.getDescription(),
             module.getSlug(),
             module.getLessons().size(),
-            lessonsToDetailedResponses(module.getLessons())
+            lessonsToDetailedResponses(module.getLessons(), userId, userProgressService)
         ))
         .toList() : null;
   }
 
   @Named("lessonsToDetailedResponses")
-  default List<RoadmapLessonDTO> lessonsToDetailedResponses(Set<Lesson> lessons) {
+  default List<RoadmapLessonDTO> lessonsToDetailedResponses(Set<Lesson> lessons, @Context Long userId, @Context UserProgressService userProgressService) {
     return lessons != null ? lessons.stream()
         .filter(Lesson::getIsPublished)
         .map(lesson -> new RoadmapLessonDTO(
             lesson.getId(),
             lesson.getName(),
             lesson.getSlug(),
-            lesson.getCredits()
+            lesson.getCredits(),
+            exercisesToDetailedResponses(lesson.getExercises(), userId, userProgressService)
         ))
+        .toList() : null;
+  }
+
+  @Named("exercisesToDetailedResponses")
+  default List<RoadmapExerciseDTO> exercisesToDetailedResponses(Set<Exercise> exercises, @Context Long userId, @Context UserProgressService userProgressService) {
+    return exercises != null ? exercises.stream()
+        .map(exercise -> RoadmapExerciseDTO.builder()
+            .id(exercise.getId())
+            .title(exercise.getTitle())
+            .slug(exercise.getSlug())
+            .points(exercise.getPoints())
+            .completed(userProgressService.isEntityCompleted(userId, exercise.getId(), EntityType.EXERCISE))
+            .build())
         .toList() : null;
   }
 }

--- a/apps/backend/education/src/main/java/com/cortex/backend/education/roadmap/internal/RoadmapServiceImpl.java
+++ b/apps/backend/education/src/main/java/com/cortex/backend/education/roadmap/internal/RoadmapServiceImpl.java
@@ -72,11 +72,11 @@ public class RoadmapServiceImpl implements RoadmapService {
   }
 
   @Override
+  @Cacheable(value = "roadmaps", key = "#slug + '_' + #userId")
   @Transactional(readOnly = true)
-  @Cacheable(value = "roadmaps", key = "#slug")
-  public Optional<RoadmapDetails> getRoadmapBySlug(String slug) {
-    return roadmapRepository.findBySlug(slug)
-        .map(roadmapMapper::toRoadmapDetails);
+  public Optional<RoadmapDetails> getRoadmapBySlug(String slug, Long userId) {
+    return roadmapRepository.findBySlugWithDetails(slug)
+        .map(roadmap -> roadmapMapper.toRoadmapDetails(roadmap, userId, userProgressService));
   }
 
 

--- a/apps/desktop/src-tauri/crates/education/src/lib.rs
+++ b/apps/desktop/src-tauri/crates/education/src/lib.rs
@@ -128,16 +128,53 @@ pub struct Course {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+pub struct RoadmapLesson {
+    pub id: u64,
+    pub name: String,
+    pub slug: String,
+    pub credits: u32,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct RoadmapModule {
+    pub id: u64,
+    pub name: String,
+    pub description: String,
+    pub slug: String,
+    #[serde(rename = "lesson_count")]
+    pub lesson_count: u32,
+    pub lessons: Vec<RoadmapLesson>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct RoadmapCourse {
+    pub id: u64,
+    pub name: String,
+    pub description: String,
+    pub slug: String,
+    #[serde(rename = "image_url")]
+    pub image_url: Option<String>,
+    #[serde(rename = "tag_names")]
+    pub tag_names: Vec<String>,
+    pub modules: Vec<RoadmapModule>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
 pub struct RoadmapDetails {
     pub id: u64,
     pub title: String,
     pub description: String,
     pub slug: String,
-    pub courses: Vec<Course>,
+    #[serde(rename = "image_url")]
     pub image_url: Option<String>,
+    #[serde(rename = "tag_names")]
     pub tag_names: Vec<String>,
+    #[serde(rename = "is_published")]
     pub is_published: bool,
+    pub courses: Vec<RoadmapCourse>,
+    #[serde(rename = "created_at")]
     pub created_at: String,
+    #[serde(rename = "updated_at")]
     pub updated_at: Option<String>,
 }
 

--- a/bruno/Education/Lesson/Get Lesson By Slug.bru
+++ b/bruno/Education/Lesson/Get Lesson By Slug.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 get {
-  url: {{BASEURL}}/api/v1/education/lesson/slug/hamir-y-la-ctm
+  url: {{BASEURL}}/api/v1/education/lesson/slug/conviertete-en-un-mago-del-codigo-con-tu-propio-juego-de-preguntas-y-respuestas
   body: none
   auth: bearer
 }

--- a/bruno/Education/Modules/Get Module By Slug.bru
+++ b/bruno/Education/Modules/Get Module By Slug.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 get {
-  url: {{BASEURL}}/api/v1/education/module/slug/la-vida-pe-causa
+  url: {{BASEURL}}/api/v1/education/module/slug/preparando-la-cafetera
   body: none
   auth: bearer
 }

--- a/bruno/Exercise/Details.bru
+++ b/bruno/Exercise/Details.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 get {
-  url: {{BASEURL}}/api/v1/exercises/1/details
+  url: {{BASEURL}}/api/v1/exercises/12/details
   body: none
   auth: bearer
 }

--- a/packages/shared/types/education.interface.ts
+++ b/packages/shared/types/education.interface.ts
@@ -99,9 +99,45 @@ export interface Course {
   updated_at: string | null;
 }
 
-export interface RoadmapDetails extends Omit<Roadmap, 'course_slugs'> {
-  courses: Course[];
+export interface RoadmapLesson {
+  id: number;
+  name: string;
+  slug: string;
+  credits: number;
 }
+
+export interface RoadmapModule {
+  id: number;
+  name: string;
+  description: string;
+  slug: string;
+  lesson_count: number;
+  lessons: RoadmapLesson[];
+}
+
+export interface RoadmapCourse {
+  id: number;
+  name: string;
+  description: string;
+  slug: string;
+  image_url: string | null;
+  tag_names: string[];
+  modules: RoadmapModule[];
+}
+
+export interface RoadmapDetails {
+  id: number;
+  title: string;
+  description: string;
+  slug: string;
+  image_url: string | null;
+  tag_names: string[];
+  is_published: boolean;
+  courses: RoadmapCourse[];
+  created_at: string;
+  updated_at: string | null;
+}
+
 
 
 export type PaginatedExercises = PaginatedResponse<Exercise>;


### PR DESCRIPTION
The changes in this commit add the user ID as a parameter to the `getRoadmapBySlug` method in the `RoadmapService`. This allows the service to retrieve the roadmap details with the user's progress information, such as which exercises have been completed. This feature is necessary to provide a personalized view of the roadmap for each user.