### PR TITLE
feat: Bump version to 0.1.4

### DIFF
--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cortex"
-version = "0.1.3"
+version = "0.1.4"
 description = "Cortex Desktop Application for Premium Users"
 authors = ["Bytech SpA"]
 license = ""

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Cortex",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "identifier": "com.cortex.app",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
Increase the version number in the Cargo.toml and tauri.conf.json files from 0.1.3 to 0.1.4. This change is necessary to reflect the latest version of the Cortex Desktop Application for Premium Users.