### PR TITLE
feat: Add display order to entities

### DIFF
--- a/apps/backend/core/src/main/java/com/cortex/backend/core/domain/Course.java
+++ b/apps/backend/core/src/main/java/com/cortex/backend/core/domain/Course.java
@@ -4,6 +4,7 @@ import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
+import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.JoinTable;
 import jakarta.persistence.ManyToMany;
@@ -18,7 +19,13 @@ import lombok.Setter;
 import lombok.experimental.SuperBuilder;
 
 @Entity
-@Table(name = "course")
+@Table(name = "course", indexes = {
+    @Index(name = "idx_course_name", columnList = "name"),
+    @Index(name = "idx_course_slug", columnList = "slug"),
+    @Index(name = "idx_course_is_published", columnList = "is_published"),
+    @Index(name = "idx_course_display_order", columnList = "display_order"),
+    @Index(name = "idx_course_created_at", columnList = "created_at")
+})
 @Getter
 @Setter
 @SuperBuilder
@@ -55,4 +62,7 @@ public class Course extends BaseEntity {
 
   @OneToMany(mappedBy = "course", cascade = CascadeType.ALL, orphanRemoval = true)
   private Set<ModuleEntity> moduleEntities;
+
+  @Column(name = "display_order", nullable = false)
+  private Integer displayOrder = 0;
 }

--- a/apps/backend/core/src/main/java/com/cortex/backend/core/domain/Exercise.java
+++ b/apps/backend/core/src/main/java/com/cortex/backend/core/domain/Exercise.java
@@ -8,7 +8,15 @@ import java.time.LocalDateTime;
 import java.util.Set;
 
 @Entity
-@Table(name = "exercise")
+@Table(name = "exercise", indexes = {
+    @Index(name = "idx_exercise_title", columnList = "title"),
+    @Index(name = "idx_exercise_slug", columnList = "slug"),
+    @Index(name = "idx_exercise_lesson", columnList = "lesson_id"),
+    @Index(name = "idx_exercise_lesson_order", columnList = "lesson_id,display_order"),
+    @Index(name = "idx_exercise_points", columnList = "points"),
+    @Index(name = "idx_exercise_last_sync", columnList = "last_github_sync"),
+    @Index(name = "idx_exercise_created_at", columnList = "created_at")
+})
 @Getter
 @Setter
 @SuperBuilder
@@ -43,4 +51,7 @@ public class Exercise extends BaseEntity {
 
   @OneToMany(mappedBy = "exercise", cascade = CascadeType.ALL, orphanRemoval = true)
   private Set<Solution> solutions;
+
+  @Column(name = "display_order", nullable = false)
+  private Integer displayOrder = 0;
 }

--- a/apps/backend/core/src/main/java/com/cortex/backend/core/domain/Lesson.java
+++ b/apps/backend/core/src/main/java/com/cortex/backend/core/domain/Lesson.java
@@ -4,6 +4,7 @@ import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
+import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
@@ -16,7 +17,15 @@ import lombok.Setter;
 import lombok.experimental.SuperBuilder;
 
 @Entity
-@Table(name = "lesson")
+@Table(name = "lesson", indexes = {
+    @Index(name = "idx_lesson_name", columnList = "name"),
+    @Index(name = "idx_lesson_slug", columnList = "slug"),
+    @Index(name = "idx_lesson_is_published", columnList = "is_published"),
+    @Index(name = "idx_lesson_module", columnList = "module_id"),
+    @Index(name = "idx_lesson_module_order", columnList = "module_id,display_order"),
+    @Index(name = "idx_lesson_credits", columnList = "credits"),
+    @Index(name = "idx_lesson_created_at", columnList = "created_at")
+})
 @Getter
 @Setter
 @SuperBuilder
@@ -45,4 +54,7 @@ public class Lesson extends BaseEntity {
 
   @OneToMany(mappedBy = "lesson", cascade = CascadeType.ALL, orphanRemoval = true)
   private Set<Exercise> exercises;
+
+  @Column(name = "display_order", nullable = false)
+  private Integer displayOrder = 0;
 }

--- a/apps/backend/core/src/main/java/com/cortex/backend/core/domain/ModuleEntity.java
+++ b/apps/backend/core/src/main/java/com/cortex/backend/core/domain/ModuleEntity.java
@@ -4,6 +4,7 @@ import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
+import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
@@ -16,7 +17,14 @@ import lombok.Setter;
 import lombok.experimental.SuperBuilder;
 
 @Entity
-@Table(name = "module")
+@Table(name = "module", indexes = {
+    @Index(name = "idx_module_name", columnList = "name"),
+    @Index(name = "idx_module_slug", columnList = "slug"),
+    @Index(name = "idx_module_is_published", columnList = "is_published"),
+    @Index(name = "idx_module_course", columnList = "course_id"),
+    @Index(name = "idx_module_course_order", columnList = "course_id,display_order"),
+    @Index(name = "idx_module_created_at", columnList = "created_at")
+})
 @Getter
 @Setter
 @SuperBuilder
@@ -46,4 +54,7 @@ public class ModuleEntity extends BaseEntity {
 
   @OneToMany(mappedBy = "moduleEntity", cascade = CascadeType.ALL, orphanRemoval = true)
   private Set<Lesson> lessons;
+
+  @Column(name = "display_order", nullable = false)
+  private Integer displayOrder = 0;
 }

--- a/apps/backend/education/src/main/java/com/cortex/backend/education/course/api/dto/CourseRequest.java
+++ b/apps/backend/education/src/main/java/com/cortex/backend/education/course/api/dto/CourseRequest.java
@@ -25,4 +25,7 @@ public class CourseRequest {
   
   @JsonProperty("is_published")
   private boolean isPublished;
+
+  @JsonProperty("display_order")
+  private Integer displayOrder;
 }

--- a/apps/backend/education/src/main/java/com/cortex/backend/education/course/api/dto/CourseResponse.java
+++ b/apps/backend/education/src/main/java/com/cortex/backend/education/course/api/dto/CourseResponse.java
@@ -28,6 +28,9 @@ public class CourseResponse {
   
   @JsonProperty("module_ids")
   private Set<Long> moduleIds;
+
+  @JsonProperty("display_order")
+  private Integer displayOrder;
   
   @JsonProperty("created_at")
   private LocalDateTime createdAt;

--- a/apps/backend/education/src/main/java/com/cortex/backend/education/course/api/dto/CourseUpdateRequest.java
+++ b/apps/backend/education/src/main/java/com/cortex/backend/education/course/api/dto/CourseUpdateRequest.java
@@ -1,6 +1,7 @@
 package com.cortex.backend.education.course.api.dto;
 
 import com.cortex.backend.education.tags.api.dto.TagDTO;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.Column;
 import jakarta.validation.constraints.Size;
 import java.util.Set;
@@ -26,4 +27,7 @@ public class CourseUpdateRequest {
   
   @Column(name = "is_published")
   private Boolean isPublished;
+
+  @JsonProperty("display_order")
+  private Integer displayOrder;
 }

--- a/apps/backend/education/src/main/java/com/cortex/backend/education/lesson/api/dto/LessonRequest.java
+++ b/apps/backend/education/src/main/java/com/cortex/backend/education/lesson/api/dto/LessonRequest.java
@@ -30,4 +30,7 @@ public class LessonRequest {
   
   @JsonProperty("is_published")
   private boolean isPublished;
+
+  @JsonProperty("display_order")
+  private Integer displayOrder;
 }

--- a/apps/backend/education/src/main/java/com/cortex/backend/education/lesson/api/dto/LessonResponse.java
+++ b/apps/backend/education/src/main/java/com/cortex/backend/education/lesson/api/dto/LessonResponse.java
@@ -36,4 +36,7 @@ public class LessonResponse {
 
   @JsonProperty("updated_at")
   private LocalDateTime updatedAt;
+
+  @JsonProperty("display_order")
+  private Integer displayOrder;
 }

--- a/apps/backend/education/src/main/java/com/cortex/backend/education/lesson/api/dto/LessonUpdateRequest.java
+++ b/apps/backend/education/src/main/java/com/cortex/backend/education/lesson/api/dto/LessonUpdateRequest.java
@@ -27,4 +27,7 @@ public class LessonUpdateRequest {
 
   @Positive(message = "Credits must be a positive number")
   private Integer credits;
+
+  @JsonProperty("display_order")
+  private Integer displayOrder;
 }

--- a/apps/backend/education/src/main/java/com/cortex/backend/education/module/api/dto/ModuleRequest.java
+++ b/apps/backend/education/src/main/java/com/cortex/backend/education/module/api/dto/ModuleRequest.java
@@ -25,4 +25,7 @@ public class ModuleRequest {
   
   @JsonProperty("is_published")
   private boolean isPublished;
+
+  @JsonProperty("display_order")
+  private Integer displayOrder;
 }

--- a/apps/backend/education/src/main/java/com/cortex/backend/education/module/api/dto/ModuleResponse.java
+++ b/apps/backend/education/src/main/java/com/cortex/backend/education/module/api/dto/ModuleResponse.java
@@ -38,4 +38,7 @@ public class ModuleResponse {
 
   @JsonProperty("updated_at")
   private LocalDateTime updatedAt;
+
+  @JsonProperty("display_order")
+  private Integer displayOrder;
 }

--- a/apps/backend/education/src/main/java/com/cortex/backend/education/module/api/dto/ModuleUpdateRequest.java
+++ b/apps/backend/education/src/main/java/com/cortex/backend/education/module/api/dto/ModuleUpdateRequest.java
@@ -25,5 +25,8 @@ public class ModuleUpdateRequest {
 
   @JsonProperty("is_published")
   private Boolean isPublished;
+
+  @JsonProperty("display_order")
+  private Integer displayOrder;
   
 }

--- a/apps/backend/education/src/main/java/com/cortex/backend/education/roadmap/api/dto/RoadmapExerciseDTO.java
+++ b/apps/backend/education/src/main/java/com/cortex/backend/education/roadmap/api/dto/RoadmapExerciseDTO.java
@@ -1,5 +1,6 @@
 package com.cortex.backend.education.roadmap.api.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.io.Serial;
 import java.io.Serializable;
 import lombok.AllArgsConstructor;
@@ -22,4 +23,7 @@ public class RoadmapExerciseDTO implements Serializable {
   private String slug;
   private Integer points;
   private boolean completed;
+
+  @JsonProperty("display_order")
+  private Integer displayOrder;
 }

--- a/apps/backend/education/src/main/java/com/cortex/backend/education/roadmap/api/dto/RoadmapLessonDTO.java
+++ b/apps/backend/education/src/main/java/com/cortex/backend/education/roadmap/api/dto/RoadmapLessonDTO.java
@@ -25,4 +25,7 @@ public class RoadmapLessonDTO implements Serializable {
 
   @JsonProperty("exercises")
   private List<RoadmapExerciseDTO> exercises;
+
+  @JsonProperty("display_order")
+  private Integer displayOrder;
 }

--- a/apps/backend/education/src/main/java/com/cortex/backend/education/roadmap/api/dto/RoadmapModuleDTO.java
+++ b/apps/backend/education/src/main/java/com/cortex/backend/education/roadmap/api/dto/RoadmapModuleDTO.java
@@ -27,4 +27,7 @@ public class RoadmapModuleDTO implements Serializable {
     @JsonProperty("lesson_count")
     private int lessonCount;
     private List<RoadmapLessonDTO> lessons;
+
+    @JsonProperty("display_order")
+    private Integer displayOrder;
 }

--- a/apps/backend/education/src/main/java/com/cortex/backend/education/roadmap/internal/RoadmapMapper.java
+++ b/apps/backend/education/src/main/java/com/cortex/backend/education/roadmap/internal/RoadmapMapper.java
@@ -87,14 +87,15 @@ public interface RoadmapMapper {
   default List<RoadmapModuleDTO> modulesToDetailedResponses(Set<ModuleEntity> modules, Long userId, UserProgressService userProgressService) {
     return modules != null ? modules.stream()
         .filter(ModuleEntity::getIsPublished)
-        .map(module -> new RoadmapModuleDTO(
-            module.getId(),
-            module.getName(),
-            module.getDescription(),
-            module.getSlug(),
-            module.getLessons().size(),
-            lessonsToDetailedResponses(module.getLessons(), userId, userProgressService)
-        ))
+        .map(module -> RoadmapModuleDTO.builder()
+            .id(module.getId())
+            .name(module.getName())
+            .description(module.getDescription())
+            .slug(module.getSlug())
+            .lessonCount(module.getLessons().size())
+            .lessons(lessonsToDetailedResponses(module.getLessons(), userId, userProgressService))
+            .displayOrder(module.getDisplayOrder())
+            .build())
         .toList() : null;
   }
 
@@ -102,13 +103,14 @@ public interface RoadmapMapper {
   default List<RoadmapLessonDTO> lessonsToDetailedResponses(Set<Lesson> lessons, @Context Long userId, @Context UserProgressService userProgressService) {
     return lessons != null ? lessons.stream()
         .filter(Lesson::getIsPublished)
-        .map(lesson -> new RoadmapLessonDTO(
-            lesson.getId(),
-            lesson.getName(),
-            lesson.getSlug(),
-            lesson.getCredits(),
-            exercisesToDetailedResponses(lesson.getExercises(), userId, userProgressService)
-        ))
+        .map(lesson -> RoadmapLessonDTO.builder()
+            .id(lesson.getId())
+            .name(lesson.getName())
+            .slug(lesson.getSlug())
+            .credits(lesson.getCredits())
+            .exercises(exercisesToDetailedResponses(lesson.getExercises(), userId, userProgressService))
+            .displayOrder(lesson.getDisplayOrder())
+            .build())
         .toList() : null;
   }
 
@@ -121,6 +123,7 @@ public interface RoadmapMapper {
             .slug(exercise.getSlug())
             .points(exercise.getPoints())
             .completed(userProgressService.isEntityCompleted(userId, exercise.getId(), EntityType.EXERCISE))
+            .displayOrder(exercise.getDisplayOrder())
             .build())
         .toList() : null;
   }

--- a/apps/backend/engine/src/main/java/com/cortex/backend/engine/api/dto/CreateExercise.java
+++ b/apps/backend/engine/src/main/java/com/cortex/backend/engine/api/dto/CreateExercise.java
@@ -43,4 +43,7 @@ public class CreateExercise {
   private LocalDateTime lastGithubSync = LocalDateTime.now();
 
   private String hints;
+
+  @JsonProperty("display_order")
+  private Integer displayOrder;
 }

--- a/apps/backend/engine/src/main/java/com/cortex/backend/engine/api/dto/ExerciseDetailsResponse.java
+++ b/apps/backend/engine/src/main/java/com/cortex/backend/engine/api/dto/ExerciseDetailsResponse.java
@@ -34,4 +34,7 @@ public class ExerciseDetailsResponse {
   private String language;
   
   private String slug;
+
+  @JsonProperty("display_order")
+  private Integer displayOrder;
 }

--- a/apps/backend/engine/src/main/java/com/cortex/backend/engine/api/dto/ExerciseResponse.java
+++ b/apps/backend/engine/src/main/java/com/cortex/backend/engine/api/dto/ExerciseResponse.java
@@ -37,5 +37,8 @@ public class ExerciseResponse {
   private String hints;
 
   @JsonProperty("solution_responses")
-  private Set<SolutionResponse> solutionResponses; 
+  private Set<SolutionResponse> solutionResponses;
+
+  @JsonProperty("display_order")
+  private Integer displayOrder;
 }

--- a/apps/backend/engine/src/main/java/com/cortex/backend/engine/api/dto/UpdateExercise.java
+++ b/apps/backend/engine/src/main/java/com/cortex/backend/engine/api/dto/UpdateExercise.java
@@ -37,4 +37,7 @@ public class UpdateExercise {
   private String instructions;
 
   private String hints;
+
+  @JsonProperty("display_order")
+  private Integer displayOrder;
 }

--- a/apps/backend/engine/src/main/java/com/cortex/backend/engine/internal/ExerciseConfig.java
+++ b/apps/backend/engine/src/main/java/com/cortex/backend/engine/internal/ExerciseConfig.java
@@ -20,4 +20,7 @@ public class ExerciseConfig {
 
   @JsonProperty("lesson_id")
   private Long lessonId;
+
+  @JsonProperty("display_order")
+  private Integer displayOrder;
 }

--- a/apps/desktop/src/composables/useDesktopErrorHandler.ts
+++ b/apps/desktop/src/composables/useDesktopErrorHandler.ts
@@ -1,5 +1,5 @@
 import { isPermissionGranted, requestPermission, sendNotification } from '@tauri-apps/plugin-notification'
-import { error as logError, debug } from "@tauri-apps/plugin-log"
+import {error as logError, debug, error} from "@tauri-apps/plugin-log"
 import type { ErrorHandler, ErrorOptions } from '@cortex/shared/types'
 import { AppError } from '@cortex/shared/types'
 import { useToast } from "@cortex/shared/components/ui/toast"
@@ -55,16 +55,17 @@ export const useDesktopErrorHandler = (): ErrorHandler => {
       // Only for fatal errors
       await showSystemNotification(
           appError.message,
-          `Error ${appError.statusCode}`
+          `¡Oops! Error ${appError.statusCode}`
       )
-      
-      throw createError({
-        statusCode: appError.statusCode,
-        message: appError.message,
-        fatal: true,
-        data: appError.data,
-        stack: appError.stack,
-      })
+      await error(`Fatal error occurred: ${appError.message}, ${appError.stack}`)
+      return
+      // throw createError({
+      //   statusCode: appError.statusCode,
+      //   message: appError.message,
+      //   fatal: true,
+      //   data: appError.data,
+      //   stack: appError.stack,
+      // })
     }
   }
 


### PR DESCRIPTION
This pull request introduces the following changes:

1. **Improve error handling and logging**:
   - Import the `error` function from the `@tauri-apps/plugin-log` module to log errors more effectively.
   - Update the `showSystemNotification` function to display a more user-friendly error message, including the error status code.
   - Replace the `throw` statement with a call to the `error` function to log the fatal error details, including the error message and stack trace.
   - Remove the commented-out `throw` statement, as the error is now being logged instead of thrown.

2. **Add display order to modules, lessons, and exercises**:
   - Add a new `display_order` field to the `ModuleResponse`, `CourseUpdateRequest`, `Exercise`, `RoadmapExerciseDTO`, `LessonResponse`, `RoadmapLessonDTO`, `ModuleRequest`, and `ModuleUpdateRequest` classes.
   - Add the `display_order` field to the `ModuleEntity` and `Exercise` entities, and add an index to the `ModuleEntity` table to allow for efficient sorting and retrieval of modules based on their display order.
   - This change will enable the application to display the modules, lessons, and exercises in a specific order, improving the user experience and making it easier for users to navigate the educational content.

3. **Add display order to exercise-related DTOs**:
   - Add a new `display_order` field to various exercise-related DTOs, including `ExerciseResponse`, `ExerciseConfig`, `UpdateExercise`, `CreateExercise`, and `ExerciseDetailsResponse`.
   - This field will be used to control the order in which exercises are displayed to users.