### PR TITLE
feat(lesson): add display order validation and mapping

### DIFF
--- a/apps/backend/education/src/main/java/com/cortex/backend/education/course/internal/CourseMapper.java
+++ b/apps/backend/education/src/main/java/com/cortex/backend/education/course/internal/CourseMapper.java
@@ -21,6 +21,7 @@ public interface CourseMapper {
   @Mapping(target = "roadmapSlugs", source = "roadmaps", qualifiedByName = "roadmapsToSlugs")
   @Mapping(target = "tagNames", source = "tags", qualifiedByName = "tagsToNames")
   @Mapping(target = "moduleIds", source = "moduleEntities", qualifiedByName = "modulesToIds")
+  @Mapping(target = "displayOrder", source = "displayOrder")
   CourseResponse toCourseResponse(Course course);
 
   @Mapping(target = "id", ignore = true)
@@ -31,6 +32,7 @@ public interface CourseMapper {
   @Mapping(target = "createdAt", ignore = true)
   @Mapping(target = "updatedAt", ignore = true)
   @Mapping(target = "isPublished", source = "published")
+  @Mapping(target = "displayOrder", source = "displayOrder")
   @Mapping(target = "slug", ignore = true)
   Course toCourse(CourseRequest courseRequest);
 

--- a/apps/backend/education/src/main/java/com/cortex/backend/education/lesson/api/dto/LessonRequest.java
+++ b/apps/backend/education/src/main/java/com/cortex/backend/education/lesson/api/dto/LessonRequest.java
@@ -36,5 +36,6 @@ public class LessonRequest {
   private boolean isPublished;
 
   @JsonProperty("display_order")
+  @Positive(message = "Display order must be a positive number")
   private Integer displayOrder;
 }

--- a/apps/backend/education/src/main/java/com/cortex/backend/education/lesson/internal/LessonMapper.java
+++ b/apps/backend/education/src/main/java/com/cortex/backend/education/lesson/internal/LessonMapper.java
@@ -2,6 +2,7 @@ package com.cortex.backend.education.lesson.internal;
 
 import com.cortex.backend.core.domain.Exercise;
 import com.cortex.backend.core.domain.Lesson;
+import com.cortex.backend.education.lesson.api.dto.LessonRequest;
 import com.cortex.backend.education.lesson.api.dto.LessonResponse;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -15,7 +16,17 @@ public interface LessonMapper {
   @Mapping(target = "moduleId", source = "moduleEntity.id")
   @Mapping(target = "moduleName", source = "moduleEntity.name")
   @Mapping(target = "exerciseIds", source = "exercises", qualifiedByName = "exercisesToIds")
+  @Mapping(target = "displayOrder", source = "displayOrder")
   LessonResponse toLessonResponse(Lesson lesson);
+
+  @Mapping(target = "isPublished", source = "published")
+  @Mapping(target = "id", ignore = true)
+  @Mapping(target = "moduleEntity", ignore = true)
+  @Mapping(target = "exercises", ignore = true)
+  @Mapping(target = "createdAt", ignore = true)
+  @Mapping(target = "updatedAt", ignore = true)
+  @Mapping(target = "displayOrder", source = "displayOrder")
+  Lesson toLesson(LessonRequest lessonRequest);
 
   @Named("exercisesToIds")
   default Set<Long> exercisesToIds(Set<Exercise> exercises) {

--- a/apps/backend/education/src/main/java/com/cortex/backend/education/lesson/internal/LessonServiceImpl.java
+++ b/apps/backend/education/src/main/java/com/cortex/backend/education/lesson/internal/LessonServiceImpl.java
@@ -71,11 +71,7 @@ public class LessonServiceImpl implements LessonService {
   @Override
   @Transactional
   public LessonResponse createLesson(LessonRequest request) {
-    Lesson lesson = new Lesson();
-    lesson.setName(request.getName());
-    lesson.setContent(request.getContent());
-    lesson.setCredits(request.getCredits());
-    lesson.setIsPublished(request.isPublished());
+    Lesson lesson = lessonMapper.toLesson(request);
     lesson.setSlug(generateUniqueSlug(request.getName()));
     setLessonModule(lesson, request.getModuleId());
     Lesson savedLesson = lessonRepository.save(lesson);

--- a/apps/backend/education/src/main/java/com/cortex/backend/education/module/api/dto/ModuleRequest.java
+++ b/apps/backend/education/src/main/java/com/cortex/backend/education/module/api/dto/ModuleRequest.java
@@ -3,6 +3,7 @@ package com.cortex.backend.education.module.api.dto;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -31,5 +32,6 @@ public class ModuleRequest {
   private boolean isPublished;
 
   @JsonProperty("display_order")
+  @Positive(message = "Display order must be a positive number")
   private Integer displayOrder;
 }

--- a/apps/backend/education/src/main/java/com/cortex/backend/education/module/internal/ModuleMapper.java
+++ b/apps/backend/education/src/main/java/com/cortex/backend/education/module/internal/ModuleMapper.java
@@ -3,6 +3,7 @@ package com.cortex.backend.education.module.internal;
 import com.cortex.backend.core.domain.Lesson;
 import com.cortex.backend.core.domain.Media;
 import com.cortex.backend.core.domain.ModuleEntity;
+import com.cortex.backend.education.module.api.dto.ModuleRequest;
 import com.cortex.backend.education.module.api.dto.ModuleResponse;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -17,7 +18,18 @@ public interface ModuleMapper {
   @Mapping(target = "courseName", source = "course.name")
   @Mapping(target = "imageUrl", source = "image", qualifiedByName = "mediaToUrl")
   @Mapping(target = "lessonIds", source = "lessons", qualifiedByName = "lessonsToIds")
+  @Mapping(target = "displayOrder", source = "displayOrder")
   ModuleResponse toModuleResponse(ModuleEntity module);
+
+  @Mapping(target = "isPublished", source = "published")
+  @Mapping(target = "id", ignore = true)
+  @Mapping(target = "course", ignore = true)
+  @Mapping(target = "image", ignore = true)
+  @Mapping(target = "lessons", ignore = true)
+  @Mapping(target = "createdAt", ignore = true)
+  @Mapping(target = "updatedAt", ignore = true)
+  @Mapping(target = "displayOrder", source = "displayOrder")
+  ModuleEntity toModule(ModuleRequest moduleRequest);
 
   @Named("mediaToUrl")
   default String mediaToUrl(Media media) {

--- a/apps/backend/education/src/main/java/com/cortex/backend/education/module/internal/ModuleServiceImpl.java
+++ b/apps/backend/education/src/main/java/com/cortex/backend/education/module/internal/ModuleServiceImpl.java
@@ -81,11 +81,8 @@ public class ModuleServiceImpl implements ModuleService {
   @Override
   @Transactional
   public ModuleResponse createModule(ModuleRequest request) {
-    ModuleEntity module = new ModuleEntity();
-    module.setName(request.getName());
-    module.setDescription(request.getDescription());
+    ModuleEntity module = moduleMapper.toModule(request);
     module.setSlug(generateUniqueSlug(request.getName()));
-    module.setIsPublished(request.isPublished());
     setCourse(module, request.getCourseId());
 
     ModuleEntity savedModule = moduleRepository.save(module);


### PR DESCRIPTION
The changes in this commit focus on the following improvements:

1. Added a `@Positive` validation constraint to the `displayOrder` field in the `LessonRequest` and `ModuleRequest` classes to ensure that the display order is a positive number.
2. Implemented mapping for the `displayOrder` field in the `CourseMapper` and `ModuleMapper` classes to map the `displayOrder` field from the request DTO to the corresponding domain entity.
3. Refactored the `createLesson` and `createModule` methods in the `LessonServiceImpl` and `ModuleServiceImpl` classes, respectively, to use the corresponding mappers to create the domain entities from the request DTOs.

These changes improve the validation and mapping of the `displayOrder` field, ensuring that the display order is a positive number and that it is correctly mapped between the request DTOs and the domain entities.