### PR TITLE
chore: Upgrade Tauri dependency to 2.1.0

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="CommitMessageInspectionProfile">
+    <profile version="1.0">
+      <inspection_tool class="CommitFormat" enabled="true" level="WARNING" enabled_by_default="true" />
+      <inspection_tool class="CommitNamingConvention" enabled="true" level="WARNING" enabled_by_default="true" />
+    </profile>
+  </component>
   <component name="VcsDirectoryMappings">
     <mapping directory="" vcs="Git" />
     <mapping directory="$PROJECT_DIR$/apps/backend/exercises" vcs="Git" />

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ resolver = "2"
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 log = "0.4.22"
-tauri = { version = "2.0.6", features = ["protocol-asset"] }
+tauri = { version = "2.1.0", features = ["protocol-asset"] }
 tauri-plugin-shell = "2.0.2"
 tauri-plugin-oauth = "2"
 tauri-plugin-store = "2.1.0"


### PR DESCRIPTION
This pull request upgrades the Tauri dependency from version 2.0.6 to 2.1.0. Additionally, it fixes the issue with drag-and-drop functionality for images on the Linux platform. The upgrade to Tauri 2.1.0 resolves the problem we had with the drag-n-drop event not including the path to the image on Linux.