### PR TITLE
feat(tauri): Refactor window management

### DIFF
--- a/apps/desktop/src-tauri/src/window.rs
+++ b/apps/desktop/src-tauri/src/window.rs
@@ -1,0 +1,93 @@
+use tauri::{
+    Manager, WebviewUrl, WebviewWindowBuilder,
+    
+};
+use log::debug;
+
+pub struct WindowManager;
+
+impl WindowManager {
+    pub fn create_windows(app: &tauri::App) -> Result<(), Box<dyn std::error::Error>> {
+        debug!("Creating application windows");
+
+        // Crear la ventana principal (inicialmente oculta)
+        let main_window = WebviewWindowBuilder::new(
+            app,
+            "main",
+            WebviewUrl::App("/".into())
+        )
+            .title("Cortex")
+            .inner_size(1100.0, 650.0)
+            .min_inner_size(800.0, 600.0)
+            .resizable(true)
+            .fullscreen(false)
+            .center()
+            .decorations(false)
+            .transparent(true)
+            .visible(false)
+            .shadow(true)
+            .build()?;
+
+        // Configurar efectos de la ventana
+        #[cfg(target_os = "windows")] {
+            use tauri::{window::{Effect, EffectState, Color, EffectsBuilder}};
+            debug!("Setting window effects for Windows");
+            main_window.set_effects(
+                EffectsBuilder::new()
+                    .effect(Effect::Acrylic)
+                    .state(EffectState::Active)
+                    .radius(5.0)
+                    .color(Color::new(0, 0, 0, 125)) 
+                    .build()
+            )?;
+        }
+
+        // Crear la ventana de splashscreen
+        let splashscreen = WebviewWindowBuilder::new(
+            app,
+            "splashscreen",
+            WebviewUrl::App("/splashscreen".into())
+        )
+            .inner_size(580.0, 400.0)
+            .min_inner_size(580.0, 400.0)
+            .max_inner_size(580.0, 400.0)
+            .resizable(false)
+            .maximizable(false)
+            .minimizable(false)
+            .center()
+            .decorations(false)
+            .transparent(true)
+            .always_on_top(true)
+            .focused(true)
+            .shadow(true)
+            .visible(true)
+            .build()?;
+
+        debug!("Windows created successfully");
+        Ok(())
+    }
+
+    pub fn handle_window_transition(app_handle: &tauri::AppHandle) -> Result<(), Box<dyn std::error::Error>> {
+        debug!("Handling window transition");
+
+        // Obtener referencias a las ventanas
+        let splash_window = app_handle
+            .get_webview_window("splashscreen")
+            .ok_or_else(|| "Splashscreen window not found".to_string())?;
+
+        let main_window = app_handle
+            .get_webview_window("main")
+            .ok_or_else(|| "Main window not found".to_string())?;
+
+        // Ocultar y cerrar splashscreen
+        splash_window.hide()?;
+        splash_window.close()?;
+
+        // Mostrar ventana principal
+        main_window.show()?;
+        main_window.set_focus()?;
+
+        debug!("Window transition completed successfully");
+        Ok(())
+    }
+}

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -9,47 +9,6 @@
     "beforeBuildCommand": "pnpm generate"
   },
   "app": {
-    "windows": [
-      {
-        "label": "main",
-        "title": "Cortex",
-        "width": 1100,
-        "height": 650,
-        "resizable": true,
-        "fullscreen": false,
-        "center": true,
-        "minHeight": 600,
-        "minWidth": 800,
-        "decorations": false,
-        "transparent": true,
-        "shadow": true,
-        "visible": false,
-        "windowEffects": {
-          "effects": [
-            "acrylic"
-          ]
-        }
-      },
-      {
-        "label": "splashscreen",
-        "url": "/splashscreen",
-        "width": 580,
-        "height": 400,
-        "minWidth": 580,
-        "minHeight": 400,
-        "maxWidth": 580,
-        "maxHeight": 400,
-        "resizable": false,
-        "maximizable": false,
-        "minimizable": false,
-        "center": true,
-        "decorations": false,
-        "shadow": true,
-        "transparent": true,
-        "alwaysOnTop": true,
-        "focus": true
-      }
-    ],
     "security": {
       "csp": {
         "default-src": "'self' blob: data: filesystem: ws: wss: http: https: tauri: 'unsafe-inline' asset: https://asset.localhost",

--- a/apps/desktop/src/pages/splashscreen.vue
+++ b/apps/desktop/src/pages/splashscreen.vue
@@ -17,23 +17,21 @@ definePageMeta({
   layout: false
 })
 
-async function initApp() {
+const initApp = async () => {
   try {
-    setTimeout(() => {
-      debug('Timeout');
-    }, 10000); // 10 seconds
-    // // Close splashscreen and show main window
-    // await invoke('close_splashscreen_show_main');
+    await debug('Starting application initialization')
+
+    // Simular tiempo de carga
+    await new Promise(resolve => setTimeout(resolve, 3000))
+
+    // await invoke('close_splashscreen_show_main')
+
+    await debug('Application initialization completed')
   } catch (error) {
-    await logError(`Error during initialization: ${error}`);
-    throw new AppError('Error during initialization', {
-      data: {
-        error: error
-      },
-    });
+    await logError(`Error during initialization: ${error}`)
+    throw new Error('Error during initialization', { cause: error })
   }
 }
-
 onMounted(() => {
   currentImage.value = splashImages[Math.floor(Math.random() * splashImages.length)];
   initApp();


### PR DESCRIPTION
This commit refactors the window management in the Tauri application. The
main changes are:

1. Moved the window creation and management logic to a dedicated
   `WindowManager` module.
2. Simplified the `tauri.conf.json` file by removing the window
   configurations and handling them programmatically in the
   `WindowManager`.
3. Added support for window effects (e.g., acrylic effect) on Windows.
4. Implemented a `handle_window_transition` function to handle the
   transition from the splashscreen to the main window.

These changes improve the maintainability and flexibility of the window
management in the application.