### PR TITLE
✨ fix: correct Mutex import and color instantiation

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -4,7 +4,7 @@ use ai_chat::keystore::manager::KeystoreManager;
 use ai_chat::session::manager::AISessionManager;
 use common::state::AppState;
 use std::sync::Arc;
-use std::sync::Mutex;g
+use std::sync::Mutex;
 use tauri::Manager;
 use tauri_plugin_log::fern::colors::ColoredLevelConfig;
 use tauri_plugin_log::RotationStrategy;

--- a/apps/desktop/src-tauri/src/window.rs
+++ b/apps/desktop/src-tauri/src/window.rs
@@ -37,7 +37,7 @@ impl WindowManager {
                     .effect(Effect::Acrylic)
                     .state(EffectState::Active)
                     .radius(5.0)
-                    .color(Color::new(0, 0, 0, 125)) 
+                    .color(Color(0, 0, 0, 125)) 
                     .build()
             )?;
         }


### PR DESCRIPTION
Fixes the Mutex import in `lib.rs` by removing an extraneous character.  
Updates the color instantiation in `window.rs` to use the correct  
constructor format for the Color struct. These changes ensure proper  
functionality and adherence to the code standards.