### PR TITLE
feat(desktop): Create Roadmaps

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -43,10 +43,12 @@
     "autoprefixer": "^10.4.20",
     "date-fns": "^4.1.0",
     "nuxt-tiptap-editor": "^2.0.0",
+    "turndown": "^7.2.0",
     "vuedraggable": "^4.1.0"
   },
   "devDependencies": {
     "@tauri-apps/cli": "2.0.4",
+    "@types/turndown": "^5.0.5",
     "cross-env": "^7.0.3"
   }
 }

--- a/apps/desktop/src-tauri/crates/common/Cargo.toml
+++ b/apps/desktop/src-tauri/crates/common/Cargo.toml
@@ -9,5 +9,6 @@ reqwest = { workspace = true }
 tauri-plugin-dialog = {workspace = true}
 tauri-plugin-fs = {workspace = true}
 tauri = {workspace = true}
+log = {workspace = true}
 infer = "0.16.0"
 error = {path = "../error"}

--- a/apps/desktop/src-tauri/crates/common/src/lib.rs
+++ b/apps/desktop/src-tauri/crates/common/src/lib.rs
@@ -1,9 +1,12 @@
+use crate::state::AppState;
 use error::AppError;
-use reqwest::multipart::Part;
+use log::debug;
+use reqwest::multipart::{Form, Part};
 use reqwest::Client;
+use serde::de::DeserializeOwned;
+use std::path::PathBuf;
 use std::sync::LazyLock;
-use tauri::AppHandle;
-use tauri_plugin_dialog::DialogExt;
+use tauri::{AppHandle, State};
 use tauri_plugin_fs::FsExt;
 
 pub mod state;
@@ -11,12 +14,8 @@ pub mod state;
 pub const API_BASE_URL: &str = "http://localhost:8088/api/v1";
 pub const MAX_IMAGE_SIZE: usize = 5 * 1024 * 1024;
 
-pub static CLIENT: LazyLock<Client> = LazyLock::new(|| {
-    Client::builder()
-        .build()
-        .expect("Failed to build reqwest client")
-});
-
+pub static CLIENT: LazyLock<Client> =
+    LazyLock::new(|| Client::builder().build().expect("Failed to build reqwest client"));
 
 pub fn validate_image_type(data: &[u8]) -> Result<(), AppError> {
     let kind = infer::get(data)
@@ -25,7 +24,7 @@ pub fn validate_image_type(data: &[u8]) -> Result<(), AppError> {
     match kind.mime_type() {
         "image/jpeg" | "image/png" | "image/webp" | "image/jpg" => Ok(()),
         _ => Err(AppError::ValidationError(
-            "Invalid file type. Only JPEG,JPG, PNG and WebP images are allowed".to_string()
+            "Invalid file type. Only JPEG,JPG, PNG and WebP images are allowed".to_string(),
         )),
     }
 }
@@ -33,7 +32,7 @@ pub fn validate_image_type(data: &[u8]) -> Result<(), AppError> {
 pub fn create_image_part(image_data: Vec<u8>) -> Result<(Part, String), AppError> {
     let kind = infer::get(&image_data)
         .ok_or_else(|| AppError::ValidationError("Unable to determine file type".to_string()))?;
-    
+
     let extension = match kind.mime_type() {
         "image/jpeg" => "jpg",
         "image/jpg" => "jpg",
@@ -41,32 +40,72 @@ pub fn create_image_part(image_data: Vec<u8>) -> Result<(Part, String), AppError
         "image/webp" => "webp",
         _ => return Err(AppError::ValidationError("Unsupported image type".to_string())),
     };
-    
+
     let filename = format!("image.{}", extension);
-    
-    let part = Part::bytes(image_data)
-        .file_name(filename.clone())
-        .mime_str(kind.mime_type())?;
+
+    let part = Part::bytes(image_data).file_name(filename.clone()).mime_str(kind.mime_type())?;
 
     Ok((part, filename))
 }
 
-pub fn handle_image_selection(
+pub async fn handle_content_image_upload<T>(
+    content_id: u64,
+    image_path: String,
+    alt_text: Option<String>,
+    content_type: &str,
     app: &AppHandle,
-    title: Option<&str>
-) -> Result<Vec<u8>, AppError> {
-    let mut dialog = app.dialog().file();
+    state: State<'_, AppState>,
+) -> Result<T, AppError>
+where
+    T: DeserializeOwned,
+{
+    debug!("Processing image upload for {} {}: {}", content_type, content_id, image_path);
+
+    let path = PathBuf::from(image_path);
+    let image_data = app
+        .fs()
+        .read(path)
+        .map_err(|e| AppError::FileError(format!("Failed to read image file: {}", e)))?;
     
-    if let Some(title_text) = title {
-        dialog = dialog.set_title(title_text);
+    if image_data.len() > MAX_IMAGE_SIZE {
+        return Err(AppError::ValidationError(
+            "Image size exceeds maximum allowed size of 5MB".to_string(),
+        ));
     }
-    
-    let file_path = dialog
-        .add_filter("Images", &["png", "jpg", "jpeg", "webp"])
-        .blocking_pick_file()
-        .ok_or_else(|| AppError::UserCancelled("File selection cancelled".into()))?;
-    
-    app.fs()
-        .read(file_path)
-        .map_err(|e| AppError::FileError(format!("Failed to read image file: {}", e)))
+
+    validate_image_type(&image_data)?;
+
+    let token = state
+        .token
+        .lock()
+        .map_err(|_| AppError::ContextLockError)?
+        .clone()
+        .ok_or(AppError::NoTokenError)?;
+
+    let mut form = Form::new();
+    let (image_part, _) = create_image_part(image_data)?;
+    form = form.part("image", image_part);
+
+    if let Some(alt_text) = alt_text {
+        form = form.text("altText", alt_text);
+    }
+
+    // Hacer la petición
+    let response = CLIENT
+        .post(format!("{}/education/{}/{}/image", API_BASE_URL, content_type, content_id))
+        .bearer_auth(token)
+        .multipart(form)
+        .send()
+        .await
+        .map_err(AppError::RequestError)?;
+
+    if !response.status().is_success() {
+        let error_msg = response.text().await.unwrap_or_else(|_| "Unknown error".to_string());
+        return Err(AppError::ApiError(format!(
+            "Failed to upload {} image: {}",
+            content_type, error_msg
+        )));
+    }
+
+    response.json::<T>().await.map_err(AppError::RequestError)
 }

--- a/apps/desktop/src-tauri/crates/education/src/courses/commands/mod.rs
+++ b/apps/desktop/src-tauri/crates/education/src/courses/commands/mod.rs
@@ -1,7 +1,7 @@
 use super::*;
-use common::handle_image_selection;
+use common::{handle_content_image_upload};
 use log::{debug, error};
-use tauri::State;
+use tauri::{AppHandle, State};
 
 #[tauri::command]
 pub async fn fetch_all_courses(state: State<'_, AppState>) -> Result<PaginatedCourses, AppError> {
@@ -82,22 +82,17 @@ pub async fn delete_course_command(id: u64, state: State<'_, AppState>) -> Resul
 #[tauri::command]
 pub async fn upload_course_image_command(
     course_id: u64,
+    image_path: String,
     alt_text: Option<String>,
-    app: tauri::AppHandle,
+    app: AppHandle,
     state: State<'_, AppState>,
 ) -> Result<Course, AppError> {
-    debug!("Opening file dialog for course image upload: {}", course_id);
-
-    let image_data = handle_image_selection(&app, Some("Select course image"))?;
-
-    match upload_course_image(course_id, image_data, alt_text, state).await {
-        Ok(course) => {
-            debug!("Successfully uploaded image for course: {}", course_id);
-            Ok(course)
-        }
-        Err(e) => {
-            error!("Failed to upload course image: {:?}", e);
-            Err(e)
-        }
-    }
+    handle_content_image_upload::<Course>(
+        course_id,
+        image_path,
+        alt_text,
+        "course",
+        &app,
+        state,
+    ).await
 }

--- a/apps/desktop/src-tauri/crates/education/src/courses/mod.rs
+++ b/apps/desktop/src-tauri/crates/education/src/courses/mod.rs
@@ -2,9 +2,8 @@ pub mod commands;
 
 use crate::{Course, CourseCreateRequest, CourseUpdateRequest, PaginatedCourses};
 use common::state::AppState;
-use common::{create_image_part, validate_image_type, API_BASE_URL, CLIENT, MAX_IMAGE_SIZE};
+use common::{API_BASE_URL, CLIENT};
 use error::AppError;
-use reqwest::multipart::Form;
 use tauri::State;
 
 pub async fn fetch_courses(state: State<'_, AppState>) -> Result<PaginatedCourses, AppError> {
@@ -128,50 +127,4 @@ pub async fn delete_course(id: u64, state: State<'_, AppState>) -> Result<(), Ap
     }
 
     Ok(())
-}
-
-pub async fn upload_course_image(
-    course_id: u64,
-    image_data: Vec<u8>,
-    alt_text: Option<String>,
-    state: State<'_, AppState>,
-) -> Result<Course, AppError> {
-    let token = state
-        .token
-        .lock()
-        .map_err(|_| AppError::ContextLockError)?
-        .clone()
-        .ok_or(AppError::NoTokenError)?;
-
-    let mut form = Form::new();
-
-    if image_data.len() > MAX_IMAGE_SIZE {
-        return Err(AppError::ValidationError(
-            "Image size exceeds maximum allowed size of 5MB".to_string(),
-        ));
-    }
-
-    validate_image_type(&image_data)?;
-
-    let (image_part, _) = create_image_part(image_data)?;
-    form = form.part("image", image_part);
-
-    if let Some(alt_text) = alt_text {
-        form = form.text("altText", alt_text);
-    }
-
-    let response = CLIENT
-        .post(format!("{}/education/course/{}/image", API_BASE_URL, course_id))
-        .bearer_auth(token)
-        .multipart(form)
-        .send()
-        .await
-        .map_err(AppError::RequestError)?;
-
-    if !response.status().is_success() {
-        let error_msg = response.text().await.unwrap_or_else(|_| "Unknown error".to_string());
-        return Err(AppError::ApiError(format!("Failed to upload course image: {}", error_msg)));
-    }
-
-    response.json::<Course>().await.map_err(AppError::RequestError)
 }

--- a/apps/desktop/src-tauri/crates/education/src/lib.rs
+++ b/apps/desktop/src-tauri/crates/education/src/lib.rs
@@ -78,9 +78,9 @@ pub struct Roadmap {
     pub description: String,
     pub slug: String,
     pub image_url: Option<String>,
-    pub tag_names: Vec<String>,
+    pub tag_names: Option<Vec<String>>,  
     pub is_published: bool,
-    pub course_slugs: Vec<String>,
+    pub course_slugs: Option<Vec<String>>,  
     pub created_at: String,
     pub updated_at: Option<String>,
 }

--- a/apps/desktop/src-tauri/crates/education/src/modules/mod.rs
+++ b/apps/desktop/src-tauri/crates/education/src/modules/mod.rs
@@ -2,9 +2,8 @@ pub mod commands;
 
 use crate::{Module, ModuleCreateRequest, ModuleUpdateRequest, PaginatedModules};
 use common::state::AppState;
-use common::{create_image_part, validate_image_type, API_BASE_URL, CLIENT, MAX_IMAGE_SIZE};
+use common::{API_BASE_URL, CLIENT};
 use error::AppError;
-use reqwest::multipart::Form;
 use tauri::State;
 
 pub async fn fetch_modules(state: State<'_, AppState>) -> Result<PaginatedModules, AppError> {
@@ -128,50 +127,4 @@ pub async fn delete_module(id: u64, state: State<'_, AppState>) -> Result<(), Ap
     }
 
     Ok(())
-}
-
-pub async fn upload_module_image(
-    module_id: u64,
-    image_data: Vec<u8>,
-    alt_text: Option<String>,
-    state: State<'_, AppState>,
-) -> Result<Module, AppError> {
-    let token = state
-        .token
-        .lock()
-        .map_err(|_| AppError::ContextLockError)?
-        .clone()
-        .ok_or(AppError::NoTokenError)?;
-
-    let mut form = Form::new();
-
-    if image_data.len() > MAX_IMAGE_SIZE {
-        return Err(AppError::ValidationError(
-            "Image size exceeds maximum allowed size of 5MB".to_string(),
-        ));
-    }
-
-    validate_image_type(&image_data)?;
-
-    let (image_part, _) = create_image_part(image_data)?;
-    form = form.part("image", image_part);
-
-    if let Some(alt_text) = alt_text {
-        form = form.text("altText", alt_text);
-    }
-
-    let response = CLIENT
-        .post(format!("{}/education/module/{}/image", API_BASE_URL, module_id))
-        .bearer_auth(token)
-        .multipart(form)
-        .send()
-        .await
-        .map_err(AppError::RequestError)?;
-
-    if !response.status().is_success() {
-        let error_msg = response.text().await.unwrap_or_else(|_| "Unknown error".to_string());
-        return Err(AppError::ApiError(format!("Failed to upload module image: {}", error_msg)));
-    }
-
-    response.json::<Module>().await.map_err(AppError::RequestError)
 }

--- a/apps/desktop/src-tauri/crates/education/src/roadmaps/commands/mod.rs
+++ b/apps/desktop/src-tauri/crates/education/src/roadmaps/commands/mod.rs
@@ -1,15 +1,15 @@
 use crate::roadmaps::{
     create_roadmap, delete_roadmap, fetch_course_from_roadmap, fetch_roadmaps,
-    fetch_roadmaps_details, update_roadmap, upload_roadmap_image,
+    fetch_roadmaps_details, update_roadmap,
 };
 use crate::{
     Course, PaginatedRoadmaps, Roadmap, RoadmapCreateRequest, RoadmapDetails, RoadmapUpdateRequest,
 };
-use common::handle_image_selection;
 use common::state::AppState;
 use error::AppError;
 use log::{debug, error};
-use tauri::State;
+use tauri::{AppHandle, State};
+use common::handle_content_image_upload;
 
 #[tauri::command]
 pub async fn fetch_all_roadmaps(state: State<'_, AppState>) -> Result<PaginatedRoadmaps, AppError> {
@@ -75,24 +75,19 @@ pub async fn create_new_roadmap(
 #[tauri::command]
 pub async fn upload_roadmap_image_command(
     roadmap_id: u64,
+    image_path: String,
     alt_text: Option<String>,
-    app: tauri::AppHandle,
+    app: AppHandle,
     state: State<'_, AppState>,
 ) -> Result<Roadmap, AppError> {
-    debug!("Opening file dialog for roadmap image upload: {}", roadmap_id);
-
-    let image_data = handle_image_selection(&app, Some("Select roadmap image"))?;
-
-    match upload_roadmap_image(roadmap_id, image_data, alt_text, state).await {
-        Ok(roadmap) => {
-            debug!("Successfully uploaded image for roadmap: {}", roadmap_id);
-            Ok(roadmap)
-        }
-        Err(e) => {
-            error!("Failed to upload roadmap image: {:?}", e);
-            Err(e)
-        }
-    }
+    handle_content_image_upload::<Roadmap>(
+        roadmap_id,
+        image_path,
+        alt_text,
+        "roadmap",
+        &app,
+        state,
+    ).await
 }
 
 #[tauri::command]

--- a/apps/desktop/src/components/education/ContentForm.vue
+++ b/apps/desktop/src/components/education/ContentForm.vue
@@ -1,42 +1,69 @@
 <script setup lang="ts">
 import type { Component } from 'vue';
-import { useImageDrop, useEducationalForm } from '~/composables';
+import {
+  useImageDrop,
+  useEducationalForm,
+  type RoadmapFormValues,
+  type CourseModuleFormValues
+} from '~/composables';
+import type { ContentType } from '~/types';
 import ContentImageUpload from "~/components/education/ContentImageUpload.vue";
 import ContentTitle from "~/components/education/ContentTitle.vue";
 import ContentTags from "~/components/education/ContentTags.vue";
 import ContentEditor from "~/components/education/ContentEditor.vue";
 import ContentFooter from "~/components/education/ContentFooter.vue";
+import type { Path } from "vee-validate";
 
 interface Props {
+  contentType: ContentType;
   iconComponent?: Component;
   submitLabel?: string;
+  isLoading?: boolean;
 }
 
-const props = withDefaults(defineProps<Props>(), {
-  submitLabel: 'Guardar'
-});
+const props = defineProps<Props>();
+
+type FormValues<T extends ContentType> = T extends 'roadmap'
+    ? RoadmapFormValues
+    : CourseModuleFormValues;
 
 const emit = defineEmits<{
-  (e: 'submit', values: never): void;
+  (e: 'submit', values: FormValues<typeof props.contentType>, imagePath: string | null): void;
 }>();
 
-const { previewImage, isDragging, setupDragListeners, handleImageUpload, cleanup } = useImageDrop();
-const { form, handleEditorUpdate } = useEducationalForm();
+const {
+  previewImage,
+  isDragging,
+  setupDragListeners,
+  handleImageUpload,
+  cleanup,
+  currentImagePath
+} = useImageDrop();
 
+const { form } = useEducationalForm(props.contentType);
 const { values, meta } = form;
 
 onMounted(setupDragListeners);
 onUnmounted(cleanup);
 
 const handleSubmit = form.handleSubmit((formValues) => {
-  emit('submit', formValues);
+  emit('submit', formValues as FormValues<typeof props.contentType>, currentImagePath.value);
+});
+
+const contentName = computed({
+  get: () => props.contentType === 'roadmap'
+      ? (values as RoadmapFormValues).title
+      : (values as CourseModuleFormValues).name,
+  set: (val: string) => {
+    const field = props.contentType === 'roadmap' ? 'title' : 'name';
+    form.setFieldValue(field as Path<typeof values>, val);
+  }
 });
 
 const handleDescriptionUpdate = (content: string) => {
   form.setFieldValue('description', content);
 };
 </script>
-
 
 <template>
   <form
@@ -47,27 +74,30 @@ const handleDescriptionUpdate = (content: string) => {
         :preview-image="previewImage"
         :is-dragging="isDragging"
         :icon-component="iconComponent"
+        :is-loading="isLoading"
         @upload="handleImageUpload"
     />
-
     <div class="max-w-4xl mx-auto space-y-8">
-      <ContentTitle v-model="values.title" />
-
-      <ContentTags v-model="values.tagNames" />
-
+      <ContentTitle
+          v-model="contentName"
+          :label="contentType === 'roadmap' ? 'Título' : 'Nombre'"
+      />
+      <ContentTags
+          v-if="contentType !== 'module'"
+          v-model="values.tagNames"
+      />
       <ContentEditor
           v-model="values.description"
           @update="handleDescriptionUpdate"
       />
-
       <ContentFooter
           v-model:is-published="values.is_published"
           :is-valid="meta.valid"
+          :is-loading="isLoading"
       >
         {{ submitLabel }}
       </ContentFooter>
     </div>
-
-    <slot name="additional-content" />
+    <slot name="additional-content"/>
   </form>
 </template>

--- a/apps/desktop/src/components/roadmap/RoadmapForm.vue
+++ b/apps/desktop/src/components/roadmap/RoadmapForm.vue
@@ -1,17 +1,27 @@
 <script setup lang="ts">
-import type { RoadmapCreateRequest } from "@cortex/shared/types";
 import RoadmapIcon from "~/components/icons/RoadmapIcon.vue";
 import ContentForm from "~/components/education/ContentForm.vue";
+import type {RoadmapFormValues} from "~/composables";
 
-defineEmits<{
-  (e: 'submit', form: RoadmapCreateRequest): void;
+defineProps<{
+  isLoading?: boolean
 }>();
+
+const emit = defineEmits<{
+  (e: 'submit', values: RoadmapFormValues, imagePath: string | null): void
+}>();
+
+const handleFormSubmit = (values: RoadmapFormValues, imagePath: string | null) => {
+  emit('submit', values, imagePath);
+};
 </script>
 
 <template>
   <ContentForm
+      content-type="roadmap"
       :icon-component="RoadmapIcon"
       submit-label="Crear Roadmap"
-      @submit="$emit('submit', $event)"
+      :is-loading="isLoading"
+      @submit="handleFormSubmit"
   />
 </template>

--- a/apps/desktop/src/composables/index.ts
+++ b/apps/desktop/src/composables/index.ts
@@ -11,3 +11,4 @@ export * from './useNavigation';
 export * from './useDesktopErrorHandler';
 export * from './useEducationalForm';
 export * from './useImageDrop';
+export * from './useEducationalContent';

--- a/apps/desktop/src/composables/useEducationalContent.ts
+++ b/apps/desktop/src/composables/useEducationalContent.ts
@@ -1,0 +1,68 @@
+import {invoke} from "@tauri-apps/api/core";
+import {debug} from "@tauri-apps/plugin-log";
+import type {
+  RoadmapCreateRequest,
+  CourseCreateRequest,
+  ModuleCreateRequest,
+  Roadmap,
+  Course,
+  Module
+  , AppError
+} from '@cortex/shared/types';
+import {CONTENT_COMMANDS, type ContentType} from "~/types";
+
+type ContentCreateRequest = RoadmapCreateRequest | CourseCreateRequest | ModuleCreateRequest;
+type ContentResponse = Roadmap | Course | Module;
+
+export function useEducationalContent(contentType: ContentType) {
+  const router = useRouter();
+  const isLoading = ref(false);
+  const error = ref<AppError | null>(null);
+  const commands = CONTENT_COMMANDS[contentType];
+
+  const createWithImage = async (
+      formData: ContentCreateRequest,
+      imagePath: string | null
+  ) => {
+    isLoading.value = true;
+    error.value = null;
+
+    try {
+      // First we create the content
+      await debug(`Creating ${contentType}...`);
+      const content = await invoke<ContentResponse>(commands.createCommand, {
+        request: formData
+      });
+
+      // If we have an image, upload it
+      if (imagePath && content.id) {
+        await debug(`Uploading image for ${contentType} ${content.id}...`);
+        await invoke(commands.uploadImageCommand, {
+          roadmapId: content.id,
+          imagePath,
+          altText: 'title' in formData ? formData.title : formData.name
+        });
+      }
+
+      await debug(`${contentType} creation completed successfully`);
+
+      // Redirect to the appropriate view based on content type
+      const slug = 'slug' in content ? content.slug : null;
+      await router.push(`${commands.redirectPath}/${slug || content.id}`);
+
+      return content;
+    } catch (e) {
+      error.value = e as AppError;
+      await debug(`Error in ${contentType} creation: ${e}`);
+      throw e;
+    } finally {
+      isLoading.value = false;
+    }
+  };
+
+  return {
+    isLoading,
+    error,
+    createWithImage
+  };
+}

--- a/apps/desktop/src/composables/useImageDrop.ts
+++ b/apps/desktop/src/composables/useImageDrop.ts
@@ -1,7 +1,6 @@
-import { ref } from 'vue';
+import { convertFileSrc } from '@tauri-apps/api/core';
 import { listen, type Event, TauriEvent } from '@tauri-apps/api/event';
 import { debug } from "@tauri-apps/plugin-log";
-import { convertFileSrc } from '@tauri-apps/api/core';
 import { open } from '@tauri-apps/plugin-dialog';
 import { AppError } from "@cortex/shared/types";
 
@@ -13,6 +12,7 @@ type DropEventPayload = {
 export function useImageDrop() {
   const previewImage = ref<string | null>(null);
   const isDragging = ref(false);
+  const currentImagePath = ref<string | null>(null);
   const unlisteners: (() => void)[] = [];
 
   const setupDragListeners = async () => {
@@ -45,6 +45,7 @@ export function useImageDrop() {
 
       if (isValidImagePath(filePath)) {
         previewImage.value = convertFileSrc(filePath);
+        currentImagePath.value = filePath;
         await debug(`Image loaded: ${filePath}`);
       }
     } catch (e) {
@@ -53,6 +54,7 @@ export function useImageDrop() {
       isDragging.value = false;
     }
   };
+
 
   const handleImageUpload = async (event?: MouseEvent) => {
     if (event) event.preventDefault();
@@ -67,17 +69,20 @@ export function useImageDrop() {
 
       if (selectedPath) {
         previewImage.value = convertFileSrc(selectedPath as string);
+        currentImagePath.value = selectedPath as string;
       }
     } catch (e) {
       throw new AppError('No image selected', { statusCode: 401, data: {e} });
     }
   };
 
+
   const cleanup = () => {
     unlisteners.forEach(unlisten => unlisten());
   };
 
   return {
+    currentImagePath,
     previewImage,
     isDragging,
     setupDragListeners,

--- a/apps/desktop/src/pages/admin/roadmaps/create.vue
+++ b/apps/desktop/src/pages/admin/roadmaps/create.vue
@@ -1,15 +1,59 @@
 <script setup lang="ts">
-import {debug} from "@tauri-apps/plugin-log";
-import type {RoadmapCreateRequest} from "@cortex/shared/types";
+import TurndownService from "turndown";
+import RoadmapIcon from "~/components/icons/RoadmapIcon.vue";
+import ContentForm from "~/components/education/ContentForm.vue";
+import type { RoadmapCreateRequest } from "@cortex/shared/types";
+import { useEducationalContent } from '~/composables/useEducationalContent';
+import { useDesktopErrorHandler } from '~/composables/useDesktopErrorHandler';
+import type { RoadmapFormValues, CourseModuleFormValues } from "~/composables";
 
+const turndownService = new TurndownService({
+  codeBlockStyle: 'fenced',
+  headingStyle: 'atx'
+});
+const { createWithImage, isLoading } = useEducationalContent('roadmap');
+const { handleError } = useDesktopErrorHandler();
 
-const handleCreateRoadmap = async (roadmapData: RoadmapCreateRequest) => {
-  await debug(`Creating roadmap with data: ${JSON.stringify(roadmapData)}`);
+const transformToRoadmapRequest = (formData: RoadmapFormValues): RoadmapCreateRequest => ({
+  title: formData.title,
+  description: turndownService.turndown(formData.description),
+  tags: formData.tagNames.map(name => ({ name })),
+  is_published: formData.is_published
+});
+
+const handleCreateRoadmap = async (
+    formData: RoadmapFormValues | CourseModuleFormValues,
+    imagePath: string | null
+) => {
+  if ('title' in formData) {
+    try {
+      const roadmapData = transformToRoadmapRequest(formData);
+      await createWithImage(roadmapData, imagePath);
+    } catch (e) {
+      await handleError(e, {
+        statusCode: 400,
+        data: { formData, imagePath },
+        silent: false
+      });
+    }
+  } else {
+    await handleError(new Error('Invalid form data type'), {
+      statusCode: 400,
+      data: { formData },
+      silent: false
+    });
+  }
 };
 </script>
 
 <template>
   <div class="p-8 w-full flex flex-col">
-    <RoadmapForm @submit="handleCreateRoadmap"/>
+    <ContentForm
+        content-type="roadmap"
+        :icon-component="RoadmapIcon"
+        submit-label="Crear Roadmap"
+        :is-loading="isLoading"
+        @submit="handleCreateRoadmap"
+    />
   </div>
 </template>

--- a/apps/desktop/src/types/education-commands.interface.ts
+++ b/apps/desktop/src/types/education-commands.interface.ts
@@ -1,0 +1,25 @@
+export type ContentType = 'roadmap' | 'course' | 'module';
+
+export interface ContentCommandConfig {
+  createCommand: string;
+  uploadImageCommand: string;
+  redirectPath: string;
+}
+
+export const CONTENT_COMMANDS: Record<ContentType, ContentCommandConfig> = {
+  roadmap: {
+    createCommand: 'create_new_roadmap',
+    uploadImageCommand: 'upload_roadmap_image_command',
+    redirectPath: '/roadmaps'
+  },
+  course: {
+    createCommand: 'create_new_course',
+    uploadImageCommand: 'upload_course_image_command',
+    redirectPath: '/courses'
+  },
+  module: {
+    createCommand: 'create_new_module',
+    uploadImageCommand: 'upload_module_image_command',
+    redirectPath: '/modules'
+  }
+};

--- a/apps/desktop/src/types/index.ts
+++ b/apps/desktop/src/types/index.ts
@@ -1,3 +1,4 @@
 export * from './user.interface';
 export * from './ai.interface';
 export * from  './navigation.interface';
+export * from './education-commands.interface';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -155,6 +155,9 @@ importers:
       nuxt-tiptap-editor:
         specifier: ^2.0.0
         version: 2.0.0(@tiptap/core@2.9.1(@tiptap/pm@2.9.1))(@tiptap/extension-code-block@2.9.1(@tiptap/core@2.9.1(@tiptap/pm@2.9.1))(@tiptap/pm@2.9.1))(highlight.js@11.9.0)(magicast@0.3.5)(rollup@4.25.0)(vue@3.5.12(typescript@5.6.3))
+      turndown:
+        specifier: ^7.2.0
+        version: 7.2.0
       vuedraggable:
         specifier: ^4.1.0
         version: 4.1.0(vue@3.5.12(typescript@5.6.3))
@@ -162,6 +165,9 @@ importers:
       '@tauri-apps/cli':
         specifier: 2.0.4
         version: 2.0.4
+      '@types/turndown':
+        specifier: ^5.0.5
+        version: 5.0.5
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
@@ -1143,6 +1149,9 @@ packages:
   '@mapbox/whoots-js@3.1.0':
     resolution: {integrity: sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q==}
     engines: {node: '>=6.0.0'}
+
+  '@mixmark-io/domino@2.2.0':
+    resolution: {integrity: sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==}
 
   '@neoconfetti/vue@2.2.1':
     resolution: {integrity: sha512-GXe5XoHlMK8VIxmxKuAgF9QQwRoDLmtiwVhONA9rzF+zOLGfOVLxo4OEDZqU9F0gJkB7U23BLlGJ3ouOb+kguw==}
@@ -2300,6 +2309,9 @@ packages:
 
   '@types/topojson@3.2.6':
     resolution: {integrity: sha512-ppfdlxjxofWJ66XdLgIlER/85RvpGyfOf8jrWf+3kVIjEatFxEZYD/Ea83jO672Xu1HRzd/ghwlbcZIUNHTskw==}
+
+  '@types/turndown@5.0.5':
+    resolution: {integrity: sha512-TL2IgGgc7B5j78rIccBtlYAnkuv8nUQqhQc+DSYV5j9Be9XOcm/SKOVRuA47xAVI3680Tk9B1d8flK2GWT2+4w==}
 
   '@types/unist@2.0.11':
     resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
@@ -6816,6 +6828,9 @@ packages:
   tunnel-agent@0.6.0:
     resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
 
+  turndown@7.2.0:
+    resolution: {integrity: sha512-eCZGBN4nNNqM9Owkv9HAtWRYfLA4h909E/WGAWWBpmB275ehNhZyk87/Tpvjbp0jjNl9XwCsbe6bm6CqFsgD+A==}
+
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
@@ -8405,6 +8420,8 @@ snapshots:
 
   '@mapbox/whoots-js@3.1.0': {}
 
+  '@mixmark-io/domino@2.2.0': {}
+
   '@neoconfetti/vue@2.2.1': {}
 
   '@netlify/functions@2.8.2':
@@ -9937,6 +9954,8 @@ snapshots:
       '@types/topojson-server': 3.0.4
       '@types/topojson-simplify': 3.0.3
       '@types/topojson-specification': 1.0.5
+
+  '@types/turndown@5.0.5': {}
 
   '@types/unist@2.0.11': {}
 
@@ -15974,6 +15993,10 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
     optional: true
+
+  turndown@7.2.0:
+    dependencies:
+      '@mixmark-io/domino': 2.2.0
 
   type-check@0.4.0:
     dependencies:


### PR DESCRIPTION
This pull request introduces the following changes:

1. Added the `@types/turndown` and `turndown` dependencies to the project.
2. Added the `log` crate to the common module's dependencies, providing logging capabilities for better debugging and error handling.
3. Implemented support for uploading roadmap images. The `upload_roadmap_image_command` function now accepts the image path and alt text, and uses the `handle_content_image_upload` function to handle the image upload process.
4. The `handle_content_image_upload` function is a generic function that can be used to upload images for different types of content, such as roadmaps, modules, etc. It handles the image validation, file size check, and API request to upload the image.
5. Removed the unused `upload_module_image` function, as the new `handle_content_image_upload` function can be used for uploading module images as well.
6. Added support for different content types (roadmap, course, and module) to the `useEducationalForm` composable. This includes introducing new interfaces, creating separate schema functions, and updating the `useEducationalForm` function to accept a `contentType` parameter.
7. Added a `currentImagePath` reactive variable to the `useImageDrop` composable to track the selected image path.
8. Updated the `ContentForm` component to accept a `contentType` prop and use the appropriate form values and schema based on the content type.