### PR TITLE
feat(roadmaps): add sort options

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="CommitMessageInspectionProfile">
+    <profile version="1.0">
+      <inspection_tool class="CommitFormat" enabled="true" level="WARNING" enabled_by_default="true" />
+      <inspection_tool class="CommitNamingConvention" enabled="true" level="WARNING" enabled_by_default="true" />
+    </profile>
+  </component>
   <component name="VcsDirectoryMappings">
     <mapping directory="" vcs="Git" />
     <mapping directory="$PROJECT_DIR$/apps/backend/exercises" vcs="Git" />

--- a/apps/backend/core/src/main/java/com/cortex/backend/core/domain/User.java
+++ b/apps/backend/core/src/main/java/com/cortex/backend/core/domain/User.java
@@ -19,6 +19,7 @@ import jakarta.persistence.Table;
 import java.security.Principal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
@@ -148,5 +149,11 @@ public class User implements UserDetails, Principal {
     }
 
     this.lastLogin = currentDate;
+  }
+
+  public boolean hasAnyRole(String... roleNames) {
+    return getRoles().stream()
+        .map(Role::getName)
+        .anyMatch(roleName -> Arrays.asList(roleNames).contains(roleName));
   }
 }

--- a/apps/backend/education/src/main/java/com/cortex/backend/education/roadmap/api/RoadmapController.java
+++ b/apps/backend/education/src/main/java/com/cortex/backend/education/roadmap/api/RoadmapController.java
@@ -74,7 +74,7 @@ public class RoadmapController {
       @PathVariable String slug,
       Authentication authentication) {
     User user = (User) authentication.getPrincipal();
-    return roadmapService.getRoadmapBySlug(slug, user.getId())
+    return roadmapService.getRoadmapBySlug(slug, user)
         .map(ResponseEntity::ok)
         .orElse(ResponseEntity.notFound().build());
   }

--- a/apps/backend/education/src/main/java/com/cortex/backend/education/roadmap/api/RoadmapRepository.java
+++ b/apps/backend/education/src/main/java/com/cortex/backend/education/roadmap/api/RoadmapRepository.java
@@ -34,4 +34,14 @@ public interface RoadmapRepository extends CrudRepository<Roadmap, Long> {
     WHERE r.slug = :slug AND r.isPublished = true
     """)
   Optional<Roadmap> findBySlugWithDetails(@Param("slug") String slug);
+
+  @Query("""
+    SELECT DISTINCT r FROM Roadmap r
+    LEFT JOIN FETCH r.courses c
+    LEFT JOIN FETCH c.moduleEntities m
+    LEFT JOIN FETCH m.lessons l
+    LEFT JOIN FETCH l.exercises e
+    WHERE r.slug = :slug
+    """)
+  Optional<Roadmap> findBySlugWithDetailsWithAdminRole(@Param("slug") String slug);
 }

--- a/apps/backend/education/src/main/java/com/cortex/backend/education/roadmap/api/RoadmapService.java
+++ b/apps/backend/education/src/main/java/com/cortex/backend/education/roadmap/api/RoadmapService.java
@@ -2,6 +2,7 @@ package com.cortex.backend.education.roadmap.api;
 
 
 import com.cortex.backend.core.common.PageResponse;
+import com.cortex.backend.core.domain.User;
 import com.cortex.backend.education.course.api.dto.CourseResponse;
 import com.cortex.backend.education.progress.api.ProgressUpdatedEvent;
 import com.cortex.backend.education.roadmap.api.dto.RoadmapDetails;
@@ -18,7 +19,7 @@ public interface RoadmapService {
 
   PageResponse<RoadmapResponse> getAllRoadmaps(int page, int size, String[] sort) ;
 
-  Optional<RoadmapDetails> getRoadmapBySlug(String slug, Long userId);
+  Optional<RoadmapDetails> getRoadmapBySlug(String slug, User user);
 
   RoadmapResponse createRoadmap(RoadmapRequest request);
 

--- a/apps/desktop/src-tauri/crates/common/src/lib.rs
+++ b/apps/desktop/src-tauri/crates/common/src/lib.rs
@@ -14,6 +14,43 @@ pub mod state;
 pub const API_BASE_URL: &str = "http://localhost:8088/api/v1";
 pub const MAX_IMAGE_SIZE: usize = 5 * 1024 * 1024;
 
+
+#[derive(Debug, Default)]
+pub struct SortQueryParams {
+    pub page: Option<u32>,
+    pub size: Option<u32>,
+    pub sort: Option<Vec<String>>,
+}
+
+impl SortQueryParams {
+    pub fn to_query_string(&self) -> String {
+        let mut params = Vec::new();
+
+        if let Some(page) = self.page {
+            params.push(format!("page={}", page));
+        }
+
+        if let Some(size) = self.size {
+            params.push(format!("size={}", size));
+        }
+
+        if let Some(sort) = &self.sort {
+            for sort_param in sort {
+                params.push(format!("sort={}", sort_param));
+            }
+        }
+
+        if params.is_empty() {
+            String::new()
+        } else {
+            format!("?{}", params.join("&"))
+        }
+    }
+}
+
+
+
+
 pub static CLIENT: LazyLock<Client> =
     LazyLock::new(|| Client::builder().build().expect("Failed to build reqwest client"));
 

--- a/apps/desktop/src-tauri/crates/education/src/roadmaps/commands/mod.rs
+++ b/apps/desktop/src-tauri/crates/education/src/roadmaps/commands/mod.rs
@@ -12,9 +12,15 @@ use tauri::{AppHandle, State};
 use common::handle_content_image_upload;
 
 #[tauri::command]
-pub async fn fetch_all_roadmaps(state: State<'_, AppState>) -> Result<PaginatedRoadmaps, AppError> {
+pub async fn fetch_all_roadmaps(
+    state: State<'_, AppState>,
+    page: Option<u32>,
+    size: Option<u32>,
+    sort: Option<Vec<String>>,
+    is_admin: bool,
+) -> Result<PaginatedRoadmaps, AppError> {
     debug!("Fetching all roadmaps");
-    match fetch_roadmaps(state).await {
+    match fetch_roadmaps(state, page, size, sort, is_admin).await {
         Ok(roadmaps) => Ok(roadmaps),
         Err(e) => {
             log::error!("Failed to fetch roadmaps: {:?}", e);
@@ -22,6 +28,7 @@ pub async fn fetch_all_roadmaps(state: State<'_, AppState>) -> Result<PaginatedR
         }
     }
 }
+
 
 #[tauri::command]
 pub async fn get_roadmap(

--- a/apps/desktop/src-tauri/crates/error/src/lib.rs
+++ b/apps/desktop/src-tauri/crates/error/src/lib.rs
@@ -70,6 +70,9 @@ pub enum AppError {
     
     #[error("File error: {0}")]
     FileError(String),
+
+    #[error("Unauthorized access")]
+    UnauthorizedError,
 }
 
 impl serde::Serialize for AppError {

--- a/apps/desktop/src/pages/explore/index.vue
+++ b/apps/desktop/src/pages/explore/index.vue
@@ -1,27 +1,51 @@
 <script setup lang="ts">
-import type { Roadmap } from '@cortex/shared/types'
+import type {Roadmap} from '@cortex/shared/types'
 import RoadmapList from '@cortex/shared/components/roadmaps/RoadmapList.vue'
 import RoadmapCardSkeleton from '@cortex/shared/components/roadmaps/RoadmapCardSkeleton.vue'
-import { useRoadmaps } from '~/composables/useRoadmaps'
+import {useRoadmaps} from '~/composables/useRoadmaps'
 
 const router = useRouter()
-const { paginatedRoadmaps, loading, fetchRoadmaps } = useRoadmaps()
-const sortBy = ref('recent')
+const {data} = useAuth();
+const {paginatedRoadmaps, loading, fetchRoadmaps} = useRoadmaps()
+const sortBy = ref<string>('recent')
 
 const handlePageChange = (page: number) => {
-  fetchRoadmaps({ page: page - 1 })
+  fetchRoadmaps({page: page - 1})
+}
+
+const getSortParam = (sort: string): string[] => {
+  switch (sort) {
+    case 'recent':
+      return ['createdAt:desc']
+    case 'oldest':
+      return ['createdAt:asc']
+    default:
+      return ['createdAt:desc']
+  }
 }
 
 const handleSortChange = (sort: string) => {
   sortBy.value = sort
-  fetchRoadmaps({ sort })
+
+  if (data?.value?.roles.includes('ADMIN')) {
+    fetchRoadmaps({isAdmin: true, sort: getSortParam(sort)})
+  }
+  fetchRoadmaps({sort: getSortParam(sort)})
 }
 
 const handleRoadmapClick = (roadmap: Roadmap) => {
   router.push(`/explore/${roadmap.slug}`)
 }
 
-onMounted(() => fetchRoadmaps())
+onMounted(() => {
+
+  if (data?.value?.roles.includes('ADMIN')) {
+    fetchRoadmaps({isAdmin: true})
+  }
+
+
+  fetchRoadmaps()
+})
 </script>
 
 <template>
@@ -30,7 +54,7 @@ onMounted(() => fetchRoadmaps())
         v-if="loading"
         class="flex flex-wrap gap-7 items-start mt-2.5 w-full max-md:max-w-full"
     >
-      <RoadmapCardSkeleton v-for="i in 6" :key="i" />
+      <RoadmapCardSkeleton v-for="i in 6" :key="i"/>
     </section>
 
     <RoadmapList

--- a/packages/shared/components/roadmaps/RoadmapCard.vue
+++ b/packages/shared/components/roadmaps/RoadmapCard.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { Roadmap } from "@cortex/shared/types"
+import { useRouter } from "vue-router"
 
 const props = defineProps<{
   roadmap: Roadmap
@@ -9,10 +10,7 @@ const emit = defineEmits<{
   (e: 'click', roadmap: Roadmap): void
 }>()
 
-import { useRouter } from 'vue-router'
-
 const router = useRouter()
-
 const handleClick = () => {
   emit('click', props.roadmap)
   router.push(`/explore/${props.roadmap.slug}`)
@@ -45,7 +43,10 @@ const handleClick = () => {
         </div>
       </div>
       <h2 class="text-xl font-medium line-clamp-1">{{ roadmap.title }}</h2>
-      <p class="text-sm text-gray-500 line-clamp-2">{{ roadmap.description }}</p>
+      <MDC
+        :value="roadmap.description"
+        class="text-sm text-gray-500 line-clamp-2"
+      />
     </CardContent>
     <Separator/>
     <CardFooter class="w-full p-2.5">

--- a/packages/shared/components/roadmaps/RoadmapList.vue
+++ b/packages/shared/components/roadmaps/RoadmapList.vue
@@ -14,6 +14,11 @@ const emit = defineEmits<{
   (e: 'pageChange', page: number): void
   (e: 'roadmapClick', roadmap: Roadmap): void
 }>()
+
+const sortOptions = [
+  { value: 'recent', label: 'Más reciente' },
+  { value: 'oldest', label: 'Más antiguo' },
+]
 </script>
 
 <template>
@@ -23,7 +28,7 @@ const emit = defineEmits<{
         {{ paginatedRoadmaps.total_elements }} Roadmaps
       </h1>
       <Select
-        v-if="props.sortBy !== undefined"
+        v-if="sortBy"
         :model-value="sortBy"
         @update:model-value="value => emit('sortChange', value)"
       >
@@ -33,10 +38,13 @@ const emit = defineEmits<{
         <SelectContent>
           <SelectGroup>
             <SelectLabel>Ordenar</SelectLabel>
-            <SelectItem value="recent">Más reciente</SelectItem>
-            <SelectItem value="oldest">Más antiguo</SelectItem>
-            <SelectItem value="popular">Más popular</SelectItem>
-            <SelectItem value="highestRated">Mejor valorado</SelectItem>
+            <SelectItem
+              v-for="option in sortOptions"
+              :key="option.value"
+              :value="option.value"
+            >
+              {{ option.label }}
+            </SelectItem>
           </SelectGroup>
         </SelectContent>
       </Select>

--- a/packages/shared/types/education.interface.ts
+++ b/packages/shared/types/education.interface.ts
@@ -225,42 +225,6 @@ export interface ImageUploadRequest {
   alt_text?: string;
 }
 
-export interface CodeExecutionRequest {
-  code: string;
-  language: string;
-  exercise_id: number;
-}
-
-export interface CodeExecutionSubmissionResponse {
-  task_id: string;
-  status: string;
-  message: string;
-  submission_time: string;
-}
-
-export interface TestCaseResult {
-  passed: boolean;
-  input?: string;
-  expected_output?: string;
-  actual_output?: string;
-  message: string;
-}
-
-export interface CodeExecutionResult {
-  success: boolean;
-  stdout: string;
-  stderr: string;
-  execution_time: number;
-  language: string;
-  exercise_id: number;
-  memory_used: number;
-  test_case_results: TestCaseResult[];
-}
-
-
-
-
-
 export type PaginatedExercises = PaginatedResponse<Exercise>;
 export type PaginatedLessons = PaginatedResponse<Lesson>;
 export type PaginatedRoadmaps = PaginatedResponse<Roadmap>;

--- a/packages/shared/types/index.ts
+++ b/packages/shared/types/index.ts
@@ -1,3 +1,4 @@
 export * from './education.interface';
 export * from './error';
 export * from './code-execution';
+export * from './sort-params.interface';

--- a/packages/shared/types/sort-params.interface.ts
+++ b/packages/shared/types/sort-params.interface.ts
@@ -1,0 +1,6 @@
+export interface SortQueryParams {
+  page?: number
+  size?: number
+  sort?: string[]
+  isAdmin?: boolean
+}


### PR DESCRIPTION
This pull request introduces several improvements and new features to the roadmap functionality in the application:

1. **Add SortQueryParams interface**: A new `SortQueryParams` interface has been added to the `shared/types` module, which defines the parameters used for sorting and pagination in API requests.

2. **Remove unused code execution interfaces**: The unused `CodeExecutionRequest`, `CodeExecutionSubmissionResponse`, `TestCaseResult`, and `CodeExecutionResult` interfaces have been removed from the `education.interface.ts` file.

3. **Add hasAnyRole method to User entity**: A new `hasAnyRole` method has been added to the `User` entity, which checks if the user has any of the specified roles. This is useful for authorization checks in the application.

4. **Add findBySlugWithDetailsWithAdminRole method**: A new `findBySlugWithDetailsWithAdminRole` method has been added to the `RoadmapRepository` interface, which is used to fetch a `Roadmap` entity along with its associated data, even when the `Roadmap` is not published. This is useful for admin users who need to access unpublished roadmaps.

5. **Implement admin access to roadmap details**: This change allows administrators and moderators to access the full details of a roadmap, including any hidden or private content.

6. **Retrieve roadmap by slug using user object**: The roadmap is now retrieved by slug using the user object instead of the user ID, providing a more secure and accurate way to access the roadmap data.

7. **Add SortQueryParams struct and to_query_string method**: A new `SortQueryParams` struct has been introduced in the `common` crate to handle the construction of query parameters for sorting and pagination. The `to_query_string` method generates the query string based on the provided parameters.

8. **Add pagination and sorting to fetch_all_roadmaps**: The `fetch_all_roadmaps` command now supports pagination and sorting, allowing the client to request a specific page of roadmaps with customizable page size and sorting options. Additionally, an `is_admin` parameter has been added to determine whether the user has the necessary permissions to fetch all roadmaps, including those that are not publicly visible.

9. **Add isAdmin parameter to fetchRoadmaps**: The `fetchRoadmaps` function in the `useRoadmaps` composable now includes an `isAdmin` parameter, which is used to determine whether the user is an admin or not, and the roadmaps returned will be filtered accordingly.

10. **Improve roadmap card and add sort options**: The RoadmapCard component has been improved by using the MDC component to display the roadmap description. Additionally, new sort options have been added to the RoadmapList component.