### PR TITLE
feat(education): update roadmap redirect path

### DIFF
--- a/apps/desktop/src/types/education-commands.interface.ts
+++ b/apps/desktop/src/types/education-commands.interface.ts
@@ -10,7 +10,7 @@ export const CONTENT_COMMANDS: Record<ContentType, ContentCommandConfig> = {
   roadmap: {
     createCommand: 'create_new_roadmap',
     uploadImageCommand: 'upload_roadmap_image_command',
-    redirectPath: '/roadmaps'
+    redirectPath: '/explore'
   },
   course: {
     createCommand: 'create_new_course',


### PR DESCRIPTION
The roadmap redirect path is updated from `/roadmaps` to `/explore` to
better align with the application's navigation structure and user
experience.