### PR TITLE
feat(education): Add sorting to get all modules, courses and lessons endpoints

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,11 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="CommitMessageInspectionProfile">
-    <profile version="1.0">
-      <inspection_tool class="CommitFormat" enabled="true" level="WARNING" enabled_by_default="true" />
-      <inspection_tool class="CommitNamingConvention" enabled="true" level="WARNING" enabled_by_default="true" />
-    </profile>
-  </component>
   <component name="VcsDirectoryMappings">
     <mapping directory="" vcs="Git" />
     <mapping directory="$PROJECT_DIR$/apps/backend/exercises" vcs="Git" />

--- a/apps/backend/education/src/main/java/com/cortex/backend/education/course/api/CourseController.java
+++ b/apps/backend/education/src/main/java/com/cortex/backend/education/course/api/CourseController.java
@@ -40,11 +40,26 @@ public class CourseController {
   @Operation(summary = "Get all courses", description = "Retrieves a list of all courses")
   @ApiResponse(responseCode = "200", description = "Successful operation",
       content = @Content(schema = @Schema(implementation = CourseResponse.class)))
+  public ResponseEntity<PageResponse<CourseResponse>> getAllPublishedCourses(
+      @RequestParam(name = "page", defaultValue = "0") int page,
+      @RequestParam(name = "size", defaultValue = "10") int size,
+      @RequestParam(name = "sort", required = false) String[] sort
+  ) {
+    return ResponseEntity.ok(courseService.getAllPublishedCourses(page, size, sort));
+  }
+
+  @GetMapping("/admin")
+  @PreAuthorize("hasAnyRole('MODERATOR', 'ADMIN')")
+  @Operation(summary = "Get all courses (including unpublished)",
+      description = "Retrieves a list of all courses. Requires ADMIN or MODERATOR role")
+  @ApiResponse(responseCode = "200", description = "Successful operation",
+      content = @Content(schema = @Schema(implementation = CourseResponse.class)))
   public ResponseEntity<PageResponse<CourseResponse>> getAllCourses(
       @RequestParam(name = "page", defaultValue = "0") int page,
-      @RequestParam(name = "size", defaultValue = "10") int size
+      @RequestParam(name = "size", defaultValue = "10") int size,
+      @RequestParam(name = "sort", required = false) String[] sort
   ) {
-    return ResponseEntity.ok(courseService.getAllCourses(page, size));
+    return ResponseEntity.ok(courseService.getAllCourses(page, size, sort));
   }
 
   @GetMapping("/{id}")

--- a/apps/backend/education/src/main/java/com/cortex/backend/education/course/api/CourseRepository.java
+++ b/apps/backend/education/src/main/java/com/cortex/backend/education/course/api/CourseRepository.java
@@ -28,4 +28,6 @@ public interface CourseRepository extends CrudRepository<Course, Long> {
       WHERE course.isPublished = true
       """)
   Page<Course> findAllPublishedCourses(Pageable pageable);
+
+  Page<Course> findAll(Pageable pageable);
 }

--- a/apps/backend/education/src/main/java/com/cortex/backend/education/course/api/CourseService.java
+++ b/apps/backend/education/src/main/java/com/cortex/backend/education/course/api/CourseService.java
@@ -11,7 +11,9 @@ import org.springframework.web.multipart.MultipartFile;
 
 public interface CourseService {
   
-  PageResponse<CourseResponse> getAllCourses(int page, int size);
+  PageResponse<CourseResponse> getAllPublishedCourses(int page, int size, String[] sort);
+
+  PageResponse<CourseResponse> getAllCourses(int page, int size, String[] sort);
   
   Optional<CourseResponse> getCourseById(Long id);
   

--- a/apps/backend/education/src/main/java/com/cortex/backend/education/course/api/dto/CourseResponse.java
+++ b/apps/backend/education/src/main/java/com/cortex/backend/education/course/api/dto/CourseResponse.java
@@ -37,4 +37,7 @@ public class CourseResponse {
   
   @JsonProperty("updated_at")
   private LocalDateTime updatedAt;
+
+  @JsonProperty("is_published")
+  private Boolean isPublished;
 }

--- a/apps/backend/education/src/main/java/com/cortex/backend/education/course/internal/CourseMapper.java
+++ b/apps/backend/education/src/main/java/com/cortex/backend/education/course/internal/CourseMapper.java
@@ -22,6 +22,7 @@ public interface CourseMapper {
   @Mapping(target = "tagNames", source = "tags", qualifiedByName = "tagsToNames")
   @Mapping(target = "moduleIds", source = "moduleEntities", qualifiedByName = "modulesToIds")
   @Mapping(target = "displayOrder", source = "displayOrder")
+  @Mapping(target = "isPublished", source = "isPublished")
   CourseResponse toCourseResponse(Course course);
 
   @Mapping(target = "id", ignore = true)

--- a/apps/backend/education/src/main/java/com/cortex/backend/education/course/internal/CourseServiceImpl.java
+++ b/apps/backend/education/src/main/java/com/cortex/backend/education/course/internal/CourseServiceImpl.java
@@ -2,6 +2,7 @@ package com.cortex.backend.education.course.internal;
 
 import com.cortex.backend.core.common.PageResponse;
 import com.cortex.backend.core.common.SlugUtils;
+import com.cortex.backend.core.common.SortUtils;
 import com.cortex.backend.core.domain.BaseEntity;
 import com.cortex.backend.core.domain.Course;
 import com.cortex.backend.core.domain.EntityType;
@@ -54,9 +55,9 @@ public class CourseServiceImpl implements CourseService {
 
   @Override
   @Transactional(readOnly = true)
-  public PageResponse<CourseResponse> getAllCourses(int page, int size) {
-
-    Pageable pageable = PageRequest.of(page, size, Sort.by("createdAt").descending());
+  public PageResponse<CourseResponse> getAllPublishedCourses(int page, int size, String[] sort) {
+    Sort sorting = SortUtils.parseSort(sort);
+    Pageable pageable = PageRequest.of(page, size, sorting);
 
     Page<Course> courses = courseRepository.findAllPublishedCourses(pageable);
 
@@ -64,6 +65,21 @@ public class CourseServiceImpl implements CourseService {
         .map(courseMapper::toCourseResponse)
         .toList();
 
+    return new PageResponse<>(
+        response, courses.getNumber(), courses.getSize(), courses.getTotalElements(),
+        courses.getTotalPages(), courses.isFirst(), courses.isLast()
+    );
+  }
+
+  @Override
+  public PageResponse<CourseResponse> getAllCourses(int page, int size, String[] sort) {
+    Sort sorting = SortUtils.parseSort(sort);
+    Pageable pageable = PageRequest.of(page, size, sorting);
+    Page<Course> courses = courseRepository.findAll(pageable);
+
+    List<CourseResponse> response = courses.stream()
+        .map(courseMapper::toCourseResponse)
+        .toList();
     return new PageResponse<>(
         response, courses.getNumber(), courses.getSize(), courses.getTotalElements(),
         courses.getTotalPages(), courses.isFirst(), courses.isLast()

--- a/apps/backend/education/src/main/java/com/cortex/backend/education/lesson/api/LessonController.java
+++ b/apps/backend/education/src/main/java/com/cortex/backend/education/lesson/api/LessonController.java
@@ -33,14 +33,27 @@ public class LessonController {
   private final LessonService lessonService;
 
   @GetMapping
+  @Operation(summary = "Get all published lessons", description = "Retrieves a list of all published lessons")
+  @ApiResponse(responseCode = "200", description = "Successful operation",
+      content = @Content(schema = @Schema(implementation = LessonResponse.class)))
+  public ResponseEntity<PageResponse<LessonResponse>> getAllPublishedLessons(
+      @RequestParam(name = "page", defaultValue = "0") int page,
+      @RequestParam(name = "size", defaultValue = "10") int size,
+      @RequestParam(name = "sort", required = false) String[] sort
+  ) {
+    return ResponseEntity.ok(lessonService.getAllPublishedLessons(page, size, sort));
+  }
+
+  @GetMapping("/admin")
   @Operation(summary = "Get all lessons", description = "Retrieves a list of all lessons")
   @ApiResponse(responseCode = "200", description = "Successful operation",
       content = @Content(schema = @Schema(implementation = LessonResponse.class)))
   public ResponseEntity<PageResponse<LessonResponse>> getAllLessons(
       @RequestParam(name = "page", defaultValue = "0") int page,
-      @RequestParam(name = "size", defaultValue = "10") int size
+      @RequestParam(name = "size", defaultValue = "10") int size,
+      @RequestParam(name = "sort", required = false) String[] sort
   ) {
-    return ResponseEntity.ok(lessonService.getAllLessons(page, size));
+    return ResponseEntity.ok(lessonService.getAllLessons(page, size, sort));
   }
 
   @GetMapping("/{id}")

--- a/apps/backend/education/src/main/java/com/cortex/backend/education/lesson/api/LessonRepository.java
+++ b/apps/backend/education/src/main/java/com/cortex/backend/education/lesson/api/LessonRepository.java
@@ -33,4 +33,6 @@ public interface LessonRepository extends CrudRepository<Lesson, Long> {
       WHERE lesson.isPublished = true
       """)
   Page<Lesson> findAllPublishedLessons(Pageable pageable);
+
+  Page<Lesson> findAll(Pageable pageable);
 }

--- a/apps/backend/education/src/main/java/com/cortex/backend/education/lesson/api/LessonService.java
+++ b/apps/backend/education/src/main/java/com/cortex/backend/education/lesson/api/LessonService.java
@@ -5,10 +5,13 @@ import com.cortex.backend.education.lesson.api.dto.LessonRequest;
 import com.cortex.backend.education.lesson.api.dto.LessonResponse;
 import com.cortex.backend.education.lesson.api.dto.LessonUpdateRequest;
 import java.util.Optional;
+import org.springframework.data.domain.Page;
 
 public interface LessonService {
 
-  PageResponse<LessonResponse> getAllLessons(int page, int size);
+  PageResponse<LessonResponse> getAllPublishedLessons(int page, int size, String[] sort);
+
+  PageResponse<LessonResponse> getAllLessons(int page, int size, String[] sort);
 
   Optional<LessonResponse> getLessonById(Long id);
 

--- a/apps/backend/education/src/main/java/com/cortex/backend/education/lesson/api/dto/LessonResponse.java
+++ b/apps/backend/education/src/main/java/com/cortex/backend/education/lesson/api/dto/LessonResponse.java
@@ -39,4 +39,7 @@ public class LessonResponse {
 
   @JsonProperty("display_order")
   private Integer displayOrder;
+
+  @JsonProperty("is_published")
+  private boolean isPublished;
 }

--- a/apps/backend/education/src/main/java/com/cortex/backend/education/lesson/internal/LessonMapper.java
+++ b/apps/backend/education/src/main/java/com/cortex/backend/education/lesson/internal/LessonMapper.java
@@ -17,6 +17,7 @@ public interface LessonMapper {
   @Mapping(target = "moduleName", source = "moduleEntity.name")
   @Mapping(target = "exerciseIds", source = "exercises", qualifiedByName = "exercisesToIds")
   @Mapping(target = "displayOrder", source = "displayOrder")
+  @Mapping(target = "isPublished", source = "isPublished")
   LessonResponse toLessonResponse(Lesson lesson);
 
   @Mapping(target = "isPublished", source = "published")

--- a/apps/backend/education/src/main/java/com/cortex/backend/education/lesson/internal/LessonServiceImpl.java
+++ b/apps/backend/education/src/main/java/com/cortex/backend/education/lesson/internal/LessonServiceImpl.java
@@ -2,6 +2,7 @@ package com.cortex.backend.education.lesson.internal;
 
 import com.cortex.backend.core.common.PageResponse;
 import com.cortex.backend.core.common.SlugUtils;
+import com.cortex.backend.core.common.SortUtils;
 import com.cortex.backend.core.domain.Lesson;
 import com.cortex.backend.core.domain.ModuleEntity;
 import com.cortex.backend.education.lesson.api.LessonRepository;
@@ -39,8 +40,9 @@ public class LessonServiceImpl implements LessonService {
 
   @Override
   @Transactional(readOnly = true)
-  public PageResponse<LessonResponse> getAllLessons(int page, int size) {
-    Pageable pageable = PageRequest.of(page, size, Sort.by("createdAt").descending());
+  public PageResponse<LessonResponse> getAllPublishedLessons(int page, int size, String[] sort) {
+    Sort sortBy = SortUtils.parseSort(sort);
+    Pageable pageable = PageRequest.of(page, size, sortBy);
 
     Page<Lesson> lessons = lessonRepository.findAllPublishedLessons(pageable);
 
@@ -51,6 +53,23 @@ public class LessonServiceImpl implements LessonService {
     return new PageResponse<>(response, lessons.getNumber(), lessons.getSize(),
         lessons.getTotalElements(), lessons.getTotalPages(), lessons.isFirst(), lessons.isLast());
 
+
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public PageResponse<LessonResponse> getAllLessons(int page, int size, String[] sort) {
+    Sort sortBy = SortUtils.parseSort(sort);
+    Pageable pageable = PageRequest.of(page, size, sortBy);
+
+    Page<Lesson> lessons = lessonRepository.findAll(pageable);
+
+    List<LessonResponse> response = lessons.stream()
+        .map(lessonMapper::toLessonResponse)
+        .toList();
+
+    return new PageResponse<>(response, lessons.getNumber(), lessons.getSize(),
+        lessons.getTotalElements(), lessons.getTotalPages(), lessons.isFirst(), lessons.isLast());
 
   }
 

--- a/apps/backend/education/src/main/java/com/cortex/backend/education/module/api/ModuleController.java
+++ b/apps/backend/education/src/main/java/com/cortex/backend/education/module/api/ModuleController.java
@@ -41,9 +41,27 @@ public class ModuleController {
       content = @Content(schema = @Schema(implementation = ModuleResponse.class)))
   public ResponseEntity<PageResponse<ModuleResponse>> getAllModules(
       @RequestParam(name = "page", defaultValue = "0") int page,
-      @RequestParam(name = "size", defaultValue = "10") int size) {
-    return ResponseEntity.ok(moduleService.getAllModules(page, size));
+      @RequestParam(name = "size", defaultValue = "10") int size,
+      @RequestParam(name = "sort", required = false) String[] sort
+  ) {
+    return ResponseEntity.ok(moduleService.getAllPublishedModules(page, size, sort));
   }
+
+
+  @GetMapping("/admin")
+  @PreAuthorize("hasAnyRole('MODERATOR', 'ADMIN')")
+  @Operation(summary = "Get all modules (including unpublished)",
+      description = "Retrieves a list of all modules. Requires ADMIN or MODERATOR role")
+  @ApiResponse(responseCode = "200", description = "Successful operation",
+      content = @Content(schema = @Schema(implementation = ModuleResponse.class)))
+  public ResponseEntity<PageResponse<ModuleResponse>> getAllCourses(
+      @RequestParam(name = "page", defaultValue = "0") int page,
+      @RequestParam(name = "size", defaultValue = "10") int size,
+      @RequestParam(name = "sort", required = false) String[] sort
+  ) {
+    return ResponseEntity.ok(moduleService.getAllModules(page, size, sort));
+  }
+
 
   @GetMapping("/{id}")
   @Operation(summary = "Get a module by ID", description = "Retrieves a module by its ID")

--- a/apps/backend/education/src/main/java/com/cortex/backend/education/module/api/ModuleRepository.java
+++ b/apps/backend/education/src/main/java/com/cortex/backend/education/module/api/ModuleRepository.java
@@ -30,6 +30,8 @@ public interface ModuleRepository extends
       """)
   Page<ModuleEntity> findAllPublishedModules(Pageable pageable);
 
+  Page<ModuleEntity> findAll(Pageable pageable);
+
   Page<ModuleEntity> findByCourse(Course course, Pageable pageable);
   Optional<ModuleEntity> findBySlugAndCourse(String slug, Course course);
 }

--- a/apps/backend/education/src/main/java/com/cortex/backend/education/module/api/ModuleService.java
+++ b/apps/backend/education/src/main/java/com/cortex/backend/education/module/api/ModuleService.java
@@ -10,7 +10,9 @@ import org.springframework.web.multipart.MultipartFile;
 
 public interface ModuleService {
 
-  PageResponse<ModuleResponse> getAllModules(int page, int size);
+  PageResponse<ModuleResponse> getAllPublishedModules(int page, int size, String[] sort);
+
+  PageResponse<ModuleResponse> getAllModules(int page, int size, String[] sort);
 
   Optional<ModuleResponse> getModuleById(Long id);
 

--- a/apps/backend/education/src/main/java/com/cortex/backend/education/module/api/dto/ModuleResponse.java
+++ b/apps/backend/education/src/main/java/com/cortex/backend/education/module/api/dto/ModuleResponse.java
@@ -41,4 +41,7 @@ public class ModuleResponse {
 
   @JsonProperty("display_order")
   private Integer displayOrder;
+
+  @JsonProperty("is_published")
+  private Boolean isPublished;
 }

--- a/apps/backend/education/src/main/java/com/cortex/backend/education/module/internal/ModuleMapper.java
+++ b/apps/backend/education/src/main/java/com/cortex/backend/education/module/internal/ModuleMapper.java
@@ -19,6 +19,7 @@ public interface ModuleMapper {
   @Mapping(target = "imageUrl", source = "image", qualifiedByName = "mediaToUrl")
   @Mapping(target = "lessonIds", source = "lessons", qualifiedByName = "lessonsToIds")
   @Mapping(target = "displayOrder", source = "displayOrder")
+  @Mapping(target = "isPublished", source = "isPublished")
   ModuleResponse toModuleResponse(ModuleEntity module);
 
   @Mapping(target = "isPublished", source = "published")

--- a/apps/backend/education/src/main/java/com/cortex/backend/education/module/internal/ModuleServiceImpl.java
+++ b/apps/backend/education/src/main/java/com/cortex/backend/education/module/internal/ModuleServiceImpl.java
@@ -2,6 +2,7 @@ package com.cortex.backend.education.module.internal;
 
 import com.cortex.backend.core.common.PageResponse;
 import com.cortex.backend.core.common.SlugUtils;
+import com.cortex.backend.core.common.SortUtils;
 import com.cortex.backend.core.domain.Course;
 import com.cortex.backend.core.domain.EntityType;
 import com.cortex.backend.core.domain.Media;
@@ -48,8 +49,9 @@ public class ModuleServiceImpl implements ModuleService {
 
   @Override
   @Transactional(readOnly = true)
-  public PageResponse<ModuleResponse> getAllModules(int page, int size) {
-    Pageable pageable = PageRequest.of(page, size, Sort.by("createdAt").descending());
+  public PageResponse<ModuleResponse> getAllPublishedModules(int page, int size, String[] sort) {
+    Sort sorting = SortUtils.parseSort(sort);
+    Pageable pageable = PageRequest.of(page, size, sorting);
 
     Page<ModuleEntity> modules = moduleRepository.findAllPublishedModules(pageable);
 
@@ -62,6 +64,23 @@ public class ModuleServiceImpl implements ModuleService {
         modules.getTotalPages(), modules.isFirst(), modules.isLast()
     );
 
+  }
+
+  @Override
+  public PageResponse<ModuleResponse> getAllModules(int page, int size, String[] sort) {
+    Sort sorting = SortUtils.parseSort(sort);
+    Pageable pageable = PageRequest.of(page, size, sorting);
+
+    Page<ModuleEntity> modules = moduleRepository.findAll(pageable);
+
+    List<ModuleResponse> response = modules.stream()
+        .map(moduleMapper::toModuleResponse)
+        .toList();
+
+    return new PageResponse<>(
+        response, modules.getNumber(), modules.getSize(), modules.getTotalElements(),
+        modules.getTotalPages(), modules.isFirst(), modules.isLast()
+    );
   }
 
   @Override

--- a/bruno/Education/Lesson/Get All Lessons.bru
+++ b/bruno/Education/Lesson/Get All Lessons.bru
@@ -1,13 +1,17 @@
 meta {
   name: Get All Lessons
   type: http
-  seq: 1
+  seq: 7
 }
 
 get {
-  url: {{BASEURL}}/api/v1/education/lesson
+  url: {{BASEURL}}/api/v1/education/lesson/admin?sort=name:asc,createdAt:asc
   body: none
   auth: bearer
+}
+
+params:query {
+  sort: name:asc,createdAt:asc
 }
 
 auth:bearer {

--- a/bruno/Education/Lesson/Get All Published Lessons.bru
+++ b/bruno/Education/Lesson/Get All Published Lessons.bru
@@ -1,11 +1,11 @@
 meta {
-  name: Get All Modules
+  name: Get All Published Lessons
   type: http
-  seq: 8
+  seq: 1
 }
 
 get {
-  url: {{BASEURL}}/api/v1/education/module/admin?sort=name:asc,createdAt:desc
+  url: {{BASEURL}}/api/v1/education/lesson?sort=name:asc,createdAt:desc
   body: none
   auth: bearer
 }

--- a/bruno/Education/Modules/Get All Published Modules.bru
+++ b/bruno/Education/Modules/Get All Published Modules.bru
@@ -1,11 +1,11 @@
 meta {
-  name: Get All Modules
+  name: Get All Published Modules
   type: http
-  seq: 8
+  seq: 1
 }
 
 get {
-  url: {{BASEURL}}/api/v1/education/module/admin?sort=name:asc,createdAt:desc
+  url: {{BASEURL}}/api/v1/education/module?sort=name:asc,createdAt:desc
   body: none
   auth: bearer
 }


### PR DESCRIPTION
The changes in this commit include:

1. Updating the `Get All Modules` endpoint to support sorting by `name` and `createdAt` in ascending and descending order.
2. Adding a new `getAllPublishedModules` method in the `ModuleService` to retrieve only published modules.
3. Updating the `ModuleController` to handle the new `getAllPublishedModules` method and add support for sorting.
4. Adding a new `getAllPublishedLessons` method in the `LessonService` to retrieve only published lessons.
5. Updating the `LessonController` to handle the new `getAllPublishedLessons` method and add support for sorting.
6. Removing the unnecessary `CommitMessageInspectionProfile` configuration from the `.idea/vcs.xml` file.
7. Adding a new `isPublished` field to the `CourseResponse` class.

These changes were made to improve the functionality and usability of the education module management features in the application.