### PR TITLE
feat(lessons): Add admin-only access to lesson list

### DIFF
--- a/apps/backend/education/src/main/java/com/cortex/backend/education/lesson/api/LessonController.java
+++ b/apps/backend/education/src/main/java/com/cortex/backend/education/lesson/api/LessonController.java
@@ -45,6 +45,7 @@ public class LessonController {
   }
 
   @GetMapping("/admin")
+  @PreAuthorize("hasAnyRole('MODERATOR', 'ADMIN')")
   @Operation(summary = "Get all lessons", description = "Retrieves a list of all lessons")
   @ApiResponse(responseCode = "200", description = "Successful operation",
       content = @Content(schema = @Schema(implementation = LessonResponse.class)))


### PR DESCRIPTION
Adds a `@PreAuthorize` annotation to the `LessonController#getAdminLessons`
endpoint, restricting access to only users with the `MODERATOR` or `ADMIN`
roles. This change ensures that the lesson list in the admin interface is
only accessible to authorized users.