### PR TITLE
fix(oauth): fix incomplete profile breaking the desktop app

### DIFF
--- a/apps/backend/core/src/main/java/com/cortex/backend/core/domain/User.java
+++ b/apps/backend/core/src/main/java/com/cortex/backend/core/domain/User.java
@@ -156,4 +156,13 @@ public class User implements UserDetails, Principal {
         .map(Role::getName)
         .anyMatch(roleName -> Arrays.asList(roleNames).contains(roleName));
   }
+
+  public boolean isProfileComplete() {
+    return username != null && !username.isBlank() &&
+        firstName != null && !firstName.isBlank() &&
+        lastName != null && !lastName.isBlank() &&
+        dateOfBirth != null &&
+        countryCode != null && !countryCode.isBlank() &&
+        gender != null;
+  }
 }

--- a/apps/desktop/src/pages/auth/login.vue
+++ b/apps/desktop/src/pages/auth/login.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import {ref, onMounted} from "vue";
+import {ref, onMounted, computed} from "vue";
 import {error as logError, info, warn} from "@tauri-apps/plugin-log";
 import {useUserStore} from '~/stores'
 import LoginForm from "~/components/auth/LoginForm.vue";
@@ -10,10 +10,13 @@ definePageMeta({
 })
 
 const {signIn, getSession} = useAuth()
-const {loginWithProviderDesktop} = useAuthStore();
+const authStore = useAuthStore();
 const userStore = useUserStore()
+
 const error = ref('')
-const loading = ref(false)
+const formLoading = ref(false)
+
+const isLoading = computed(() => formLoading.value || authStore.loading)
 
 onMounted(async () => {
   await userStore.initStore()
@@ -25,26 +28,26 @@ onMounted(async () => {
     } else {
       await warn('No auth token found in store')
     }
-
     await info(`User already logged in: ${user.username}`)
-
   }
 })
 
 const handleSubmit = async (credentials: { username: string; password: string }) => {
   error.value = ''
-  loading.value = true
+  formLoading.value = true
+
   try {
     const response = await signIn(credentials, {callbackUrl: '/'})
     if (response?.error) {
       throw new Error(response.error)
     }
+
     const session = await getSession()
     if (session) {
       await info(`User logged in: ${session.username}`)
       await userStore.setUser(session)
 
-      // Obtener el token de la cookie
+      // We obtain the auth token from the cookie
       const authToken = useCookie('auth.token')
       if (authToken.value) {
         await userStore.setToken({token: authToken.value})
@@ -56,27 +59,21 @@ const handleSubmit = async (credentials: { username: string; password: string })
     await logError(`Login error: ${err}`)
     error.value = err instanceof Error ? err.message : 'Invalid credentials'
   } finally {
-    loading.value = false
+    formLoading.value = false
   }
 }
 
 const handleLoginWithProvider = (provider: 'github' | 'google') => {
-  loginWithProviderDesktop(provider)
+  authStore.loginWithProviderDesktop(provider)
 }
 </script>
-
 
 <template>
   <div class="flex w-full min-w-[364px] max-w-[470px] self-start justify-center items-center">
     <LoginForm
-        :loading="loading"
+        :loading="isLoading"
         @submit="handleSubmit"
         @login="handleLoginWithProvider"
     />
-
-    <Alert v-if="error" variant="destructive" class="mt-4">
-      <AlertTitle>Error</AlertTitle>
-      <AlertDescription>{{ error }}</AlertDescription>
-    </Alert>
   </div>
 </template>

--- a/apps/desktop/src/stores/auth.store.ts
+++ b/apps/desktop/src/stores/auth.store.ts
@@ -1,9 +1,10 @@
 import {invoke} from '@tauri-apps/api/core'
 import {listen} from '@tauri-apps/api/event'
+import {confirm} from '@tauri-apps/plugin-dialog';
 import {open} from '@tauri-apps/plugin-shell'
-import {debug, info} from '@tauri-apps/plugin-log'
+import {debug, info, warn} from '@tauri-apps/plugin-log'
 import {API_ROUTES} from "@cortex/shared/config/api"
-import { AppError } from '@cortex/shared/types'
+import {AppError} from '@cortex/shared/types'
 
 interface OAuthConfig {
   provider: string
@@ -11,6 +12,8 @@ interface OAuthConfig {
   code_challenge: string
   port: number
 }
+
+const AUTH_TIMEOUT = 5 * 60 * 1000 // 5 minutes
 
 export const useAuthStore = defineStore('auth', () => {
   const userStore = useUserStore()
@@ -20,6 +23,7 @@ export const useAuthStore = defineStore('auth', () => {
   const errorHandler = useDesktopErrorHandler()
 
   const isAuthCompleted = ref(false)
+  const loading = ref(false)
 
   const cleanup = async (port?: number, unlisten?: () => void) => {
     try {
@@ -34,25 +38,39 @@ export const useAuthStore = defineStore('auth', () => {
     }
   }
 
-  const extractTokenFromUrl = (url: string): string | null => {
+  const extractTokenFromUrl =  (url: string): { token: string | null, requiresProfile: boolean } => {
     try {
       debug(`Parsing callback URL: ${url}`)
       const urlParams = new URLSearchParams(new URL(url).search)
-      return urlParams.get('token')
+      return {
+        token: urlParams.get('token'),
+        requiresProfile: urlParams.get('requiresProfile') === 'true'
+      }
     } catch (error) {
-      throw new AppError(`Failed to parse callback URL: ${error}`, {
-        statusCode: 400,
-        data: { url }
-      })
+      throw new Error(`Failed to parse callback URL: ${error}`)
     }
   }
 
   const loginWithProviderDesktop = async (provider: 'github' | 'google') => {
     let port: number | undefined
     let unlisten: (() => void) | undefined
+    let timeoutId: NodeJS.Timeout | undefined
+
     isAuthCompleted.value = false
+    loading.value = true
 
     try {
+      // Configurar timeout para el flujo OAuth
+      timeoutId = setTimeout(() => {
+        throw new AppError('La autenticación ha expirado. Por favor, intenta de nuevo.', {
+          statusCode: 408,
+          data: {
+            provider,
+            action: 'oauth_timeout'
+          }
+        })
+      }, AUTH_TIMEOUT)
+
       const config = await invoke<OAuthConfig>('start_oauth_flow', {
         provider
       })
@@ -71,13 +89,31 @@ export const useAuthStore = defineStore('auth', () => {
       unlisten = await listen('oauth://url', async (event) => {
         try {
           const callbackUrl = event.payload as string
-          const token = extractTokenFromUrl(callbackUrl)
+          const {token, requiresProfile} = extractTokenFromUrl(callbackUrl)
 
           if (!token) {
             throw new AppError('No token received in callback URL', {
               statusCode: 401,
-              data: { callbackUrl }
+              data: {callbackUrl}
             })
+          }
+
+          if (requiresProfile) {
+            const confirmation = await confirm(
+                'Necesitas completar tu perfil, ¿quieres hacerlo ahora? De lo contrario, no podrás continuar.',
+                {title: '¡Espera!', kind: 'warning'}
+            );
+
+            if (!confirmation) {
+              await warn('User declined to complete profile')
+              await cleanup(port, unlisten)
+              return
+            }
+
+            await info('User needs to complete profile, redirecting to web app...')
+            await userStore.setToken({token})
+            await open('http://localhost:3000/auth/complete-profile')
+            return
           }
 
           await userStore.setToken({token})
@@ -93,7 +129,11 @@ export const useAuthStore = defineStore('auth', () => {
             await router.push('/')
           } else {
             throw new AppError('Failed to get user session after authentication', {
-              statusCode: 401
+              statusCode: 401,
+              data: {
+                provider,
+                hasToken: !!token
+              }
             })
           }
         } catch (error) {
@@ -106,6 +146,8 @@ export const useAuthStore = defineStore('auth', () => {
             }
           })
           await cleanup(port, unlisten)
+        } finally {
+          if (timeoutId) clearTimeout(timeoutId)
         }
       })
     } catch (error) {
@@ -117,10 +159,15 @@ export const useAuthStore = defineStore('auth', () => {
           provider
         }
       })
+    } finally {
+      if (timeoutId) clearTimeout(timeoutId)
+      loading.value = false
     }
   }
 
   return {
-    loginWithProviderDesktop
+    loginWithProviderDesktop,
+    loading,
+    isAuthCompleted
   }
 })


### PR DESCRIPTION
## Description

This pull request introduces the following changes:

1. **Redirect desktop clients with incomplete profiles**: The `PKCEAwareOAuth2SuccessHandler` class has been updated to handle desktop clients with incomplete user profiles. If the user's profile is not complete, the handler will redirect the client to the same redirect URI, but with additional query parameters indicating that the profile is incomplete and needs to be updated.

2. **Implement OAuth login flow for desktop app**: The `loginWithProviderDesktop` function in the `auth.store.ts` file has been refactored to handle the OAuth login flow more robustly. This includes adding a timeout to the login process, handling the case where the user needs to complete their profile after logging in, and cleaning up the listener and port when the login process is completed. The `login.vue` component has also been updated to use the updated `loginWithProviderDesktop` function, and a new `isLoading` computed property has been introduced to track the overall loading state.

These changes improve the user experience and reliability of the desktop app's OAuth login flow.