### PR TITLE
feat(CodeEditor): add line wrapping option

### DIFF
--- a/packages/shared/components/CodeEditor.vue
+++ b/packages/shared/components/CodeEditor.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
 import { ref } from 'vue'
 import type { ViewUpdate } from "@codemirror/view"
-import type {Extension} from "@codemirror/state";
+import type { Extension } from "@codemirror/state"
 import type { CodeMirrorRef } from "#build/nuxt-codemirror"
-import type { ThemeKey } from '../composables/editor';
+import type { ThemeKey } from '../composables/editor'
 import { useEditorCode, useEditorExtensions, useEditorTheme } from '../composables/editor'
 import { useCodeExecutionStore } from "../stores/useCodeExecutionStore"
 import ExecuteCodeButton from "./exercise/ExecuteCodeButton.vue"
@@ -13,14 +13,16 @@ const props = withDefaults(defineProps<{
   language: string
   placeholder?: string
   availableExtensions: string[]
-  availableThemes: Record<ThemeKey, Extension> // Actualizamos este tipo
+  availableThemes: Record<ThemeKey, Extension>
   activeExtensions: string[]
   activeTheme: ThemeKey
+  lineWrapping?: boolean
 }>(), {
   placeholder: "// Type some code here",
   availableExtensions: () => ["lineNumbersRelative", "indentationMarkers", "interact"],
   activeExtensions: () => ["lineNumbersRelative", "indentationMarkers", "interact"],
-  activeTheme: "materialDark"
+  activeTheme: "materialDark",
+  lineWrapping: true
 })
 
 const emit = defineEmits<{
@@ -32,7 +34,11 @@ const emit = defineEmits<{
 const codeExecutionStore = useCodeExecutionStore()
 const codemirror = ref<CodeMirrorRef>()
 
-const { extensions } = useEditorExtensions(props)
+const { extensions } = useEditorExtensions({
+  language: props.language,
+  activeExtensions: props.activeExtensions,
+  lineWrapping: props.lineWrapping
+})
 const { activeTheme } = useEditorTheme(props, codemirror)
 const { code, handleChange, handleUpdate, handleStatistics } = useEditorCode(props, emit)
 

--- a/packages/shared/composables/editor/useEditorExtensions.ts
+++ b/packages/shared/composables/editor/useEditorExtensions.ts
@@ -1,4 +1,5 @@
 import { computed } from 'vue'
+import { EditorView } from "@codemirror/view"
 import { javascript } from "@codemirror/lang-javascript"
 import { loadLanguage } from "@uiw/codemirror-extensions-langs"
 import { indentationMarkers } from "@replit/codemirror-indentation-markers"
@@ -10,7 +11,8 @@ import { useEditorLinting, useEditorCompletions } from './'
 
 export function useEditorExtensions(props: {
   language: string
-  activeExtensions: string[]
+  activeExtensions: string[],
+  lineWrapping?: boolean
 }) {
   const { getLanguageCompletions } = useEditorCompletions()
   const { getLanguageLinter } = useEditorLinting()
@@ -43,12 +45,22 @@ export function useEditorExtensions(props: {
     return extension
   }
 
+  const lineWrappingExtension = computed((): CodeMirrorExtension => {
+    return EditorView.lineWrapping
+  })
+
+
+
   const extensions = computed((): CodeMirrorExtension[] => {
     const exts: CodeMirrorExtension[] = [
       getLanguageExtension(props.language),
       getLanguageLinter(props.language),
       getLanguageCompletions(props.language)
     ]
+
+    if (props.lineWrapping) {
+      exts.push(lineWrappingExtension.value)
+    }
 
     if (props.activeExtensions.includes("lineNumbersRelative")) {
       exts.push(lineNumbersRelative)


### PR DESCRIPTION
This commit adds a new `lineWrapping` prop to the `CodeEditor` component and the `useEditorExtensions` composable. This allows users to enable or disable line wrapping in the code editor.

The changes include:

- Add `lineWrapping` prop to the `CodeEditor` component with a default value of `true`.
- Update the `useEditorExtensions` composable to include the `lineWrapping` option and add the `lineWrappingExtension` to the list of extensions if `lineWrapping` is enabled.
- Update the type definition for the `useEditorExtensions` function to include the `lineWrapping` option.

These changes provide more flexibility for users to customize the code editor's behavior and improve the overall user experience.