### PR TITLE
✨ feat: add Material Design Components configuration

### DIFF
--- a/apps/frontend/nuxt.config.ts
+++ b/apps/frontend/nuxt.config.ts
@@ -41,6 +41,35 @@ export default defineNuxtConfig({
   pinia: {
     storesDirs: ['src/stores/**'],
   },
+  mdc: {
+    components: {
+      prose: true,
+      map: {
+        h1: 'ProseH1',
+        h2: 'ProseH2',
+        h3: 'ProseH3',
+        p: 'ProseP',
+        ul: 'ProseUl',
+        li: 'ProseLi',
+        code: 'ProseCode'
+      },
+    },
+    headings: {
+      anchorLinks: {
+        h1: false,
+        h2: false,
+        h3: false,
+        h4: false,
+        h5: false,
+        h6: false
+      }
+    },
+    highlight: {
+      theme: 'material-theme-ocean',
+      langs: ['js', 'jsx', 'json', 'ts', 'tsx', 'vue', 'css', 'html', 'bash', 'md', 'mdc', 'yaml', "rust", "java", "python", "go", "csharp"],
+      wrapperStyle: true
+    }
+  },
   colorMode: {
     classSuffix: '',
   },


### PR DESCRIPTION
Add configuration for Material Design Components (MDC) in the Nuxt 
application. This includes custom component mappings for prose 
elements, disabling anchor links for headings, and setting up syntax 
highlighting with a specific theme and language support. These changes