### PR TITLE
fix(engine): NullPointerException in Rust exercises

### DIFF
--- a/apps/backend/engine/src/main/java/com/cortex/backend/engine/internal/parser/RustTestResultParser.java
+++ b/apps/backend/engine/src/main/java/com/cortex/backend/engine/internal/parser/RustTestResultParser.java
@@ -7,22 +7,10 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class RustTestResultParser implements TestResultParser {
-
-  // Patrones para diferentes partes de la salida
   private static final Pattern TEST_PATTERN = Pattern.compile("test ([^.]+) \\.{3} (ok|FAILED)");
-  private static final String ERROR_INDICATOR = "error";
-  private static final String WARNING_INDICATOR = "warning";
-  private static final int MAX_ERROR_LENGTH = 1000;
-  private static final int MAX_ERROR_LINES = 10;
   private static final Pattern SUMMARY_PATTERN = Pattern.compile(
-      "test result: (ok|FAILED)\\. (\\d+) passed; (\\d+) failed;");
-
-  // Mensajes constantes
-  private static final String COMPILATION_ERROR_PREFIX = "Compilation error: ";
-  private static final String TEST_EXECUTION = "Test execution";
-  private static final String EXPECTED_OUTPUT = "All tests should pass";
-  private static final String SUCCESS_OUTPUT = "All tests passed";
-  private static final String FAILURE_OUTPUT = "One or more tests failed";
+      "test result: (ok|FAILED)\\. (\\d+) passed; (\\d+) failed; (\\d+) ignored; (\\d+) measured;.*?finished in ([\\d.]+)s");
+  private static final Pattern ERROR_PATTERN = Pattern.compile("error[E\\d+]*: .*", Pattern.MULTILINE);
 
   @Override
   public List<TestCaseResult> parseTestResults(String output) {
@@ -30,14 +18,17 @@ public class RustTestResultParser implements TestResultParser {
       return List.of(createErrorResult("No test output provided"));
     }
 
-    String compilationError = findCompilationError(output);
-    if (compilationError != null) {
-      return List.of(createErrorResult(COMPILATION_ERROR_PREFIX + compilationError.trim()));
+    // Check for actual errors
+    Matcher errorMatcher = ERROR_PATTERN.matcher(output);
+    if (errorMatcher.find()) {
+      return List.of(createErrorResult(errorMatcher.group()));
     }
 
+    // Parse individual test results
     List<TestCaseResult> results = parseIndividualTests(output);
 
-    if (results.isEmpty()) {
+    // Add summary only if we found actual tests
+    if (!results.isEmpty()) {
       TestCaseResult summaryResult = parseSummary(output);
       if (summaryResult != null) {
         results.add(summaryResult);
@@ -51,72 +42,6 @@ public class RustTestResultParser implements TestResultParser {
     return output != null && !output.trim().isEmpty();
   }
 
-  private String findCompilationError(String output) {
-    StringBuilder errorMessage = new StringBuilder();
-    boolean inError = false;
-    int errorLines = 0;
-
-    List<String> significantLines = output.lines()
-        .filter(line -> !line.trim().isEmpty())
-        .toList();
-
-    for (String line : significantLines) {
-      ProcessedLine result = processLine(line, inError, errorLines, errorMessage);
-      inError = result.inError();
-      errorLines = result.errorLines();
-
-      if (result.shouldStop()) {
-        break;
-      }
-    }
-
-    String error = errorMessage.toString().trim();
-    return error.isEmpty() ? null : error;
-  }
-
-  private record ProcessedLine(boolean inError, int errorLines, boolean shouldStop) {
-
-  }
-
-  private ProcessedLine processLine(String line, boolean inError, int errorLines,
-      StringBuilder errorMessage) {
-    // Detectar nuevo error
-    if (isNewError(line)) {
-      if (inError) {
-        errorMessage.append("---\n");
-      }
-      errorMessage.append(line).append("\n");
-      return new ProcessedLine(true, 1, false);
-    }
-
-    // Continuar con error existente
-    if (inError && errorLines < MAX_ERROR_LINES && isErrorContinuation(line)) {
-      errorMessage.append(line).append("\n");
-      return new ProcessedLine(true, errorLines + 1,
-          errorMessage.length() > MAX_ERROR_LENGTH);
-    }
-
-    // Finalizar error actual
-    if (inError) {
-      if (errorMessage.length() > MAX_ERROR_LENGTH) {
-        errorMessage.setLength(MAX_ERROR_LENGTH);
-        errorMessage.append("...");
-        return new ProcessedLine(false, errorLines, true);
-      }
-      return new ProcessedLine(false, errorLines, false);
-    }
-
-    return new ProcessedLine(false, errorLines, false);
-  }
-
-  private boolean isNewError(String line) {
-    return line.contains(ERROR_INDICATOR) && !line.contains(WARNING_INDICATOR);
-  }
-
-  private boolean isErrorContinuation(String line) {
-    return line.startsWith(" ") || line.startsWith("\t");
-  }
-
   private List<TestCaseResult> parseIndividualTests(String output) {
     List<TestCaseResult> results = new ArrayList<>();
     Matcher matcher = TEST_PATTERN.matcher(output);
@@ -128,8 +53,8 @@ public class RustTestResultParser implements TestResultParser {
       results.add(TestCaseResult.builder()
           .passed(passed)
           .input(testName)
-          .expectedOutput(EXPECTED_OUTPUT)
-          .actualOutput(passed ? SUCCESS_OUTPUT : FAILURE_OUTPUT)
+          .expectedOutput("Test should pass")
+          .actualOutput(passed ? "Test passed" : "Test failed")
           .message(passed ?
               String.format("Test '%s' passed successfully", testName) :
               String.format("Test '%s' failed", testName))
@@ -140,31 +65,68 @@ public class RustTestResultParser implements TestResultParser {
   }
 
   private TestCaseResult parseSummary(String output) {
-    Matcher matcher = SUMMARY_PATTERN.matcher(output);
-    if (matcher.find()) {
-      boolean passed = "ok".equals(matcher.group(1));
-      int passedCount = Integer.parseInt(matcher.group(2));
-      int failedCount = Integer.parseInt(matcher.group(3));
+    int totalPassed = 0;
+    int totalFailed = 0;
+    int totalIgnored = 0;
+    double totalTime = 0.0;
 
+    Matcher matcher = SUMMARY_PATTERN.matcher(output);
+    while (matcher.find()) {
+      totalPassed += Integer.parseInt(matcher.group(2));
+      totalFailed += Integer.parseInt(matcher.group(3));
+      totalIgnored += Integer.parseInt(matcher.group(4));
+      totalTime += Double.parseDouble(matcher.group(6));
+    }
+
+    if (totalPassed > 0 || totalFailed > 0) {
+      boolean allPassed = totalFailed == 0;
       return TestCaseResult.builder()
-          .passed(passed)
-          .input(TEST_EXECUTION)
-          .expectedOutput(EXPECTED_OUTPUT)
-          .actualOutput(passed ? SUCCESS_OUTPUT : FAILURE_OUTPUT)
-          .message(String.format("Tests completed: %d passed, %d failed",
-              passedCount, failedCount))
+          .passed(allPassed)
+          .input("Test Summary")
+          .expectedOutput("All tests should pass")
+          .actualOutput(formatSummaryOutput(totalPassed, totalFailed, totalIgnored))
+          .message(formatSummaryMessage(totalPassed, totalFailed, totalIgnored, totalTime))
           .build();
     }
     return null;
   }
 
+  private String formatSummaryOutput(int passed, int failed, int ignored) {
+    StringBuilder output = new StringBuilder();
+    output.append(String.format("%d test%s passed", passed, passed != 1 ? "s" : ""));
+    if (failed > 0) {
+      output.append(String.format(", %d failed", failed));
+    }
+    if (ignored > 0) {
+      output.append(String.format(", %d ignored", ignored));
+    }
+    return output.toString();
+  }
+
+  private String formatSummaryMessage(int passed, int failed, int ignored, double time) {
+    StringBuilder message = new StringBuilder();
+    if (failed == 0 && ignored == 0) {
+      message.append(String.format("All %d tests passed successfully", passed));
+    } else {
+      message.append(String.format("Tests completed: %d passed", passed));
+      if (failed > 0) {
+        message.append(String.format(", %d failed", failed));
+      }
+      if (ignored > 0) {
+        message.append(String.format(", %d ignored", ignored));
+      }
+    }
+    message.append(String.format(" (%.2fs)", time));
+    return message.toString();
+  }
+
   private TestCaseResult createErrorResult(String message) {
     return TestCaseResult.builder()
         .passed(false)
-        .input(TEST_EXECUTION)
+        .input("Test Execution")
+        .expectedOutput("Tests should execute successfully")
+        .actualOutput("Test execution failed")
         .message(message)
-        .expectedOutput(EXPECTED_OUTPUT)
-        .actualOutput(FAILURE_OUTPUT)
         .build();
   }
 }


### PR DESCRIPTION
This pull request addresses a null pointer exception that was occurring in the `CodeExecutionService` when processing code execution for Rust. The issue was caused by the `getLesson()` method of the `Exercise` class returning a null value, which led to a `NullPointerException` when trying to call the `getId()` method on the returned `Lesson` object.

The changes in this PR include:

1. Improved error handling in the `CodeExecutionService` to handle the `EntityNotFoundException` when the exercise is not found, providing a more informative error message.
2. Tracking progress for the exercise only if the exercise is associated with a lesson.
3. Checking for lesson completion only if the exercise is associated with a lesson, and publishing a `LessonCompletedEvent` if all exercises for the lesson are completed.
4. Adding the `exerciseId` to the error result, which can be useful for debugging purposes.