### PR TITLE
feat(enrollment): add enrollment status and roadmap enrollment entity

### DIFF
--- a/apps/backend/core/src/main/java/com/cortex/backend/core/common/BusinessErrorCodes.java
+++ b/apps/backend/core/src/main/java/com/cortex/backend/core/common/BusinessErrorCodes.java
@@ -48,6 +48,7 @@ public enum BusinessErrorCodes {
   NO_APPROVED_MENTORSHIP_REQUEST(325, NOT_FOUND, "No approved mentorship request found for this mentee"),
   PAYMENT_FAILED(326, INTERNAL_SERVER_ERROR, "Payment failed"),
   RESOURCE_NOT_FOUND(327, NOT_FOUND, "Resource not found"),
+  ALREADY_ENROLLED(328, BAD_REQUEST, "User already enrolled in this roadmap"),
   ;
   private final int code;
   private final String description;

--- a/apps/backend/core/src/main/java/com/cortex/backend/core/common/exception/AlreadyEnrolledException.java
+++ b/apps/backend/core/src/main/java/com/cortex/backend/core/common/exception/AlreadyEnrolledException.java
@@ -1,0 +1,8 @@
+package com.cortex.backend.core.common.exception;
+
+public class AlreadyEnrolledException extends RuntimeException {
+  public AlreadyEnrolledException(String message) {
+    super(message);
+  }
+
+}

--- a/apps/backend/core/src/main/java/com/cortex/backend/core/domain/EnrollmentStatus.java
+++ b/apps/backend/core/src/main/java/com/cortex/backend/core/domain/EnrollmentStatus.java
@@ -1,0 +1,6 @@
+package com.cortex.backend.core.domain;
+
+public enum EnrollmentStatus {
+  ACTIVE, PAUSED, DROPPED, COMPLETED
+}
+

--- a/apps/backend/core/src/main/java/com/cortex/backend/core/domain/RoadmapEnrollment.java
+++ b/apps/backend/core/src/main/java/com/cortex/backend/core/domain/RoadmapEnrollment.java
@@ -1,0 +1,38 @@
+package com.cortex.backend.core.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "roadmap_enrollment", indexes = {
+    @Index(name = "idx_enrollment_user_id", columnList = "user_id"),
+    @Index(name = "idx_enrollment_roadmap_id", columnList = "roadmap_id"),
+    @Index(name = "idx_enrollment_status", columnList = "status")
+})
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class RoadmapEnrollment {
+  @EmbeddedId
+  private RoadmapEnrollmentId id;
+
+  @Column(nullable = false)
+  private LocalDateTime enrollmentDate;
+
+  @Enumerated(EnumType.STRING)
+  private EnrollmentStatus status; //
+
+  @Column(name = "last_activity_date")
+  private LocalDateTime lastActivityDate;
+}

--- a/apps/backend/core/src/main/java/com/cortex/backend/core/domain/RoadmapEnrollmentId.java
+++ b/apps/backend/core/src/main/java/com/cortex/backend/core/domain/RoadmapEnrollmentId.java
@@ -1,0 +1,22 @@
+package com.cortex.backend.core.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import java.io.Serializable;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Embeddable
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class RoadmapEnrollmentId implements Serializable {
+  @Column(name = "user_id")
+  private Long userId;
+
+  @Column(name = "roadmap_id")
+  private Long roadmapId;
+}

--- a/apps/backend/core/src/main/java/com/cortex/backend/core/handler/GlobalExceptionHandler.java
+++ b/apps/backend/core/src/main/java/com/cortex/backend/core/handler/GlobalExceptionHandler.java
@@ -4,6 +4,7 @@ package com.cortex.backend.core.handler;
 import static com.cortex.backend.core.common.BusinessErrorCodes.ACCESS_DENIED;
 import static com.cortex.backend.core.common.BusinessErrorCodes.ACCOUNT_DISABLED;
 import static com.cortex.backend.core.common.BusinessErrorCodes.ACCOUNT_LOCKED;
+import static com.cortex.backend.core.common.BusinessErrorCodes.ALREADY_ENROLLED;
 import static com.cortex.backend.core.common.BusinessErrorCodes.BAD_CREDENTIALS;
 import static com.cortex.backend.core.common.BusinessErrorCodes.CODE_EXECUTION_FAILED;
 import static com.cortex.backend.core.common.BusinessErrorCodes.CONTAINER_EXECUTION_FAILED;
@@ -35,6 +36,7 @@ import static org.springframework.http.HttpStatus.FORBIDDEN;
 import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 import static org.springframework.http.HttpStatus.UNAUTHORIZED;
 
+import com.cortex.backend.core.common.exception.AlreadyEnrolledException;
 import com.cortex.backend.core.common.exception.CodeExecutionException;
 import com.cortex.backend.core.common.exception.ContainerExecutionException;
 import com.cortex.backend.core.common.exception.ContentChangedException;
@@ -423,7 +425,7 @@ public class GlobalExceptionHandler {
                 .build());
   }
 
-@ExceptionHandler(InvalidPrerequisiteException.class)
+  @ExceptionHandler(InvalidPrerequisiteException.class)
   public ResponseEntity<ExceptionResponse> handleInvalidPrerequisiteException(
       InvalidPrerequisiteException exp) {
     return ResponseEntity.status(INVALID_PREREQUISITE.getHttpStatus())
@@ -447,6 +449,18 @@ public class GlobalExceptionHandler {
                 .build());
   }
 
+
+  @ExceptionHandler(AlreadyEnrolledException.class)
+  public ResponseEntity<ExceptionResponse> handleAlreadyEnrolledException(
+      AlreadyEnrolledException exp) {
+    return ResponseEntity.status(ALREADY_ENROLLED.getHttpStatus())
+        .body(
+            ExceptionResponse.builder()
+                .code(ALREADY_ENROLLED.getCode())
+                .description(ALREADY_ENROLLED.getDescription())
+                .error(exp.getMessage())
+                .build());
+  }
 
 
   @ExceptionHandler(Exception.class)

--- a/apps/backend/education/src/main/java/com/cortex/backend/education/progress/api/RoadmapEnrollmentEvent.java
+++ b/apps/backend/education/src/main/java/com/cortex/backend/education/progress/api/RoadmapEnrollmentEvent.java
@@ -1,0 +1,5 @@
+package com.cortex.backend.education.progress.api;
+
+public record RoadmapEnrollmentEvent(Long userId, Long roadmapId) {
+
+}

--- a/apps/backend/education/src/main/java/com/cortex/backend/education/roadmap/api/RoadmapEnrollmentRepository.java
+++ b/apps/backend/education/src/main/java/com/cortex/backend/education/roadmap/api/RoadmapEnrollmentRepository.java
@@ -1,0 +1,24 @@
+package com.cortex.backend.education.roadmap.api;
+
+import com.cortex.backend.core.domain.EnrollmentStatus;
+import com.cortex.backend.core.domain.RoadmapEnrollment;
+import com.cortex.backend.core.domain.RoadmapEnrollmentId;
+import java.util.List;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RoadmapEnrollmentRepository extends
+    CrudRepository<RoadmapEnrollment, RoadmapEnrollmentId> {
+
+  List<RoadmapEnrollment> findByIdUserId(Long userId);
+
+  @Query("SELECT re FROM RoadmapEnrollment re " +
+      "WHERE re.id.userId = :userId AND re.status = :status")
+  List<RoadmapEnrollment> findActiveEnrollments(Long userId, EnrollmentStatus status);
+
+  @Query("SELECT COUNT(re) > 0 FROM RoadmapEnrollment re " +
+      "WHERE re.id.userId = :userId AND re.id.roadmapId = :roadmapId")
+  boolean isEnrolled(Long userId, Long roadmapId);
+}

--- a/apps/backend/education/src/main/java/com/cortex/backend/education/roadmap/api/RoadmapService.java
+++ b/apps/backend/education/src/main/java/com/cortex/backend/education/roadmap/api/RoadmapService.java
@@ -23,6 +23,8 @@ public interface RoadmapService {
 
   Optional<RoadmapDetails> getRoadmapBySlug(String slug, User user);
 
+  Optional<RoadmapResponse> getRoadmapById(Long id);
+
   RoadmapResponse createRoadmap(RoadmapRequest request);
 
   RoadmapResponse updateRoadmap(Long id, RoadmapUpdateRequest request);

--- a/apps/backend/education/src/main/java/com/cortex/backend/education/roadmap/api/dto/RoadmapEnrollmentRequest.java
+++ b/apps/backend/education/src/main/java/com/cortex/backend/education/roadmap/api/dto/RoadmapEnrollmentRequest.java
@@ -1,0 +1,11 @@
+package com.cortex.backend.education.roadmap.api.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record RoadmapEnrollmentRequest(
+    @JsonProperty("roadmap_id")
+    Long roadmapId
+
+) {
+
+}

--- a/apps/backend/education/src/main/java/com/cortex/backend/education/roadmap/api/dto/RoadmapEnrollmentResponse.java
+++ b/apps/backend/education/src/main/java/com/cortex/backend/education/roadmap/api/dto/RoadmapEnrollmentResponse.java
@@ -1,0 +1,23 @@
+package com.cortex.backend.education.roadmap.api.dto;
+
+import com.cortex.backend.core.domain.EnrollmentStatus;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.LocalDateTime;
+
+public record RoadmapEnrollmentResponse(
+    @JsonProperty("user_id")
+    Long userId,
+    @JsonProperty("roadmap_id")
+    Long roadmapId,
+
+    @JsonProperty("enrollment_date")
+    LocalDateTime enrollmentDate,
+
+    EnrollmentStatus status,
+
+    @JsonProperty("last_activity_date")
+    LocalDateTime lastActivityDate,
+    double progress
+) {
+
+}

--- a/apps/backend/education/src/main/java/com/cortex/backend/education/roadmap/internal/RoadmapEnrollmentMapper.java
+++ b/apps/backend/education/src/main/java/com/cortex/backend/education/roadmap/internal/RoadmapEnrollmentMapper.java
@@ -1,0 +1,22 @@
+package com.cortex.backend.education.roadmap.internal;
+
+import com.cortex.backend.core.domain.RoadmapEnrollment;
+import com.cortex.backend.education.roadmap.api.dto.RoadmapEnrollmentResponse;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface RoadmapEnrollmentMapper {
+  default RoadmapEnrollmentResponse toResponse(
+      RoadmapEnrollment enrollment,
+      double progress
+  ) {
+    return new RoadmapEnrollmentResponse(
+        enrollment.getId().getUserId(),
+        enrollment.getId().getRoadmapId(),
+        enrollment.getEnrollmentDate(),
+        enrollment.getStatus(),
+        enrollment.getLastActivityDate(),
+        progress
+    );
+  }
+}

--- a/apps/backend/education/src/main/java/com/cortex/backend/education/roadmap/internal/RoadmapEnrollmentService.java
+++ b/apps/backend/education/src/main/java/com/cortex/backend/education/roadmap/internal/RoadmapEnrollmentService.java
@@ -1,0 +1,84 @@
+package com.cortex.backend.education.roadmap.internal;
+
+import com.cortex.backend.core.common.exception.AlreadyEnrolledException;
+import com.cortex.backend.core.common.exception.ResourceNotFoundException;
+import com.cortex.backend.core.domain.EnrollmentStatus;
+import com.cortex.backend.core.domain.EntityType;
+import com.cortex.backend.core.domain.RoadmapEnrollment;
+import com.cortex.backend.core.domain.RoadmapEnrollmentId;
+import com.cortex.backend.education.course.api.CourseService;
+import com.cortex.backend.education.course.api.dto.CourseResponse;
+import com.cortex.backend.education.progress.api.ProgressTrackingService;
+import com.cortex.backend.education.progress.api.RoadmapEnrollmentEvent;
+import com.cortex.backend.education.roadmap.api.RoadmapEnrollmentRepository;
+import com.cortex.backend.education.roadmap.api.RoadmapService;
+import com.cortex.backend.education.roadmap.api.dto.RoadmapEnrollmentResponse;
+import com.cortex.backend.education.roadmap.api.dto.RoadmapResponse;
+import jakarta.transaction.Transactional;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RoadmapEnrollmentService {
+
+  private final RoadmapEnrollmentRepository enrollmentRepository;
+  private final CourseService courseService;
+  private final RoadmapService roadmapService;
+  private final ProgressTrackingService progressTrackingService;
+  private final ApplicationEventPublisher eventPublisher;
+  private final RoadmapEnrollmentMapper enrollmentMapper;
+
+  @Transactional
+  public RoadmapEnrollmentResponse enrollUserInRoadmap(Long userId, Long roadmapId) {
+    if (enrollmentRepository.isEnrolled(userId, roadmapId)) {
+      throw new AlreadyEnrolledException("User already enrolled in this roadmap");
+    }
+
+    RoadmapEnrollmentId enrollmentId = new RoadmapEnrollmentId(userId, roadmapId);
+    RoadmapEnrollment enrollment = new RoadmapEnrollment(
+        enrollmentId,
+        LocalDateTime.now(),
+        EnrollmentStatus.ACTIVE,
+        LocalDateTime.now()
+    );
+
+    enrollment = enrollmentRepository.save(enrollment);
+    eventPublisher.publishEvent(new RoadmapEnrollmentEvent(userId, roadmapId));
+
+    double progress = calculateRoadmapProgress(userId, roadmapId);
+    return enrollmentMapper.toResponse(enrollment, progress);
+  }
+
+  public List<RoadmapEnrollmentResponse> getUserEnrollments(Long userId) {
+    return enrollmentRepository.findByIdUserId(userId).stream()
+        .map(enrollment -> {
+          double progress = calculateRoadmapProgress(userId, enrollment.getId().getRoadmapId());
+          return enrollmentMapper.toResponse(enrollment, progress);
+        })
+        .toList();
+  }
+
+  public double calculateRoadmapProgress(Long userId, Long roadmapId) {
+    RoadmapResponse roadmap = roadmapService.getRoadmapById(roadmapId)
+        .orElseThrow(() -> new ResourceNotFoundException("Roadmap not found"));
+
+    long totalCourses = roadmap.getCourseSlugs().size();
+    if (totalCourses == 0) {
+      return 0.0;
+    }
+
+    long completedCourses = roadmap.getCourseSlugs().stream()
+        .map(slug -> courseService.getCourseBySlug(slug)
+            .map(CourseResponse::getId)
+            .orElse(null))
+        .filter(courseId -> courseId != null &&
+            progressTrackingService.isEntityCompleted(userId, courseId, EntityType.COURSE))
+        .count();
+
+    return (double) completedCourses / totalCourses * 100;
+  }
+}

--- a/apps/backend/education/src/main/java/com/cortex/backend/education/roadmap/internal/RoadmapServiceImpl.java
+++ b/apps/backend/education/src/main/java/com/cortex/backend/education/roadmap/internal/RoadmapServiceImpl.java
@@ -119,6 +119,12 @@ public class RoadmapServiceImpl implements RoadmapService {
   }
 
   @Override
+  public Optional<RoadmapResponse> getRoadmapById(Long id) {
+    return roadmapRepository.findById(id)
+        .map(roadmapMapper::toRoadmapResponse);
+  }
+
+  @Override
   @Transactional
   public RoadmapResponse createRoadmap(RoadmapRequest request) {
     Roadmap roadmap = roadmapMapper.toRoadmap(request);
@@ -296,13 +302,15 @@ public class RoadmapServiceImpl implements RoadmapService {
 
   @Override
   @Transactional(readOnly = true)
-  public Optional<PageResponse<CourseResponse>> getRoadmapCourses(Long roadmapId, int page, int size, String[] sort) {
+  public Optional<PageResponse<CourseResponse>> getRoadmapCourses(Long roadmapId, int page,
+      int size, String[] sort) {
     return roadmapRepository.findById(roadmapId)
         .map(roadmap -> {
           Sort sorting = SortUtils.parseSort(sort);
           Pageable pageable = PageRequest.of(page, size, sorting);
 
-          Page<Course> courses = courseRepository.findByRoadmapsContainingOrderByDisplayOrderAsc(roadmap, pageable);
+          Page<Course> courses = courseRepository.findByRoadmapsContainingOrderByDisplayOrderAsc(
+              roadmap, pageable);
 
           List<CourseResponse> courseResponses = courses.stream()
               .map(courseMapper::toCourseResponse)

--- a/bruno/Education/Roadmap/Enroll.bru
+++ b/bruno/Education/Roadmap/Enroll.bru
@@ -1,0 +1,15 @@
+meta {
+  name: Enroll
+  type: http
+  seq: 10
+}
+
+post {
+  url: {{BASEURL}}/api/v1/education/roadmap/1/enroll
+  body: none
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{token}}
+}

--- a/bruno/Education/Roadmap/Enrollments.bru
+++ b/bruno/Education/Roadmap/Enrollments.bru
@@ -1,0 +1,15 @@
+meta {
+  name: Enrollments
+  type: http
+  seq: 11
+}
+
+get {
+  url: {{BASEURL}}/api/v1/education/roadmap/enrollments
+  body: none
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{token}}
+}


### PR DESCRIPTION
This commit introduces the `EnrollmentStatus` enum and the `RoadmapEnrollment` entity to the backend application. The changes include:

- Added the `EnrollmentStatus` enum with values `ACTIVE`, `PAUSED`, `DROPPED`, and `COMPLETED`.
- Created the `RoadmapEnrollment` entity to store information about a user's enrollment in a roadmap, including the enrollment date, status, and last activity date.
- Implemented the `RoadmapEnrollmentMapper` to map the `RoadmapEnrollment` entity to a `RoadmapEnrollmentResponse` DTO.
- Updated the `RoadmapServiceImpl` to use the new `RoadmapEnrollment` entity when retrieving roadmap courses.
- Added the `AlreadyEnrolledException` exception to handle cases where a user is already enrolled in a roadmap.
- Updated the `GlobalExceptionHandler` to handle the `InvalidPrerequisiteException`.

These changes are necessary to support the management of user enrollments in roadmaps, which is a key feature of the education platform.