### PR TITLE
feat(user): Add endpoint to retrieve user by email

### DIFF
--- a/apps/backend/user/src/main/java/com/cortex/backend/user/api/UserController.java
+++ b/apps/backend/user/src/main/java/com/cortex/backend/user/api/UserController.java
@@ -27,6 +27,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -108,5 +109,17 @@ public class UserController {
       @RequestBody List<String> roleNames) {
     UserResponse updatedUser = userService.updateUserRoles(userId, roleNames);
     return ResponseEntity.ok(updatedUser);
+  }
+
+
+  @GetMapping
+  @PreAuthorize("hasAnyRole('MODERATOR', 'ADMIN')")
+  @Operation(summary = "Get user by email", description = "Retrieves a user by their email address (Admin and Moderator only)")
+  @ApiResponse(responseCode = "200", description = "User retrieved successfully",
+      content = @Content(schema = @Schema(implementation = UserResponse.class)))
+  public ResponseEntity<UserResponse> getUserByEmail(
+      @Parameter(description = "Email address of the user to retrieve")
+      @RequestParam String email) {
+    return ResponseEntity.ok(userService.getUserByEmail(email).orElseThrow());
   }
 }

--- a/bruno/User/Get User By Email.bru
+++ b/bruno/User/Get User By Email.bru
@@ -1,0 +1,19 @@
+meta {
+  name: Get User By Email
+  type: http
+  seq: 8
+}
+
+get {
+  url: {{BASEURL}}/api/v1/user?email=angel.cuervo187@gmail.com
+  body: none
+  auth: bearer
+}
+
+params:query {
+  email: angel.cuervo187@gmail.com
+}
+
+auth:bearer {
+  token: {{token}}
+}


### PR DESCRIPTION
This commit adds a new endpoint to the UserController that allows
retrieving a user by their email address. The endpoint is secured
with the MODERATOR and ADMIN roles, and it returns a UserResponse
object containing the user's details.

The new endpoint is implemented in the getUserByEmail method, which
takes an email parameter and uses the userService to fetch the user
by email. If the user is found, it is returned in the response,
otherwise a 404 Not Found exception is thrown.