### PR TITLE
feat(progress-tracking): Add new method to track progress and check completion

### DIFF
--- a/apps/backend/app/src/main/java/com/cortex/backend/Application.java
+++ b/apps/backend/app/src/main/java/com/cortex/backend/Application.java
@@ -12,7 +12,6 @@ import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableScheduling;
-import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootApplication
 @EnableJpaAuditing(auditorAwareRef = "auditorAware")

--- a/apps/backend/app/src/main/java/com/cortex/backend/config/TransactionConfig.java
+++ b/apps/backend/app/src/main/java/com/cortex/backend/config/TransactionConfig.java
@@ -1,0 +1,18 @@
+package com.cortex.backend.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.support.TransactionTemplate;
+
+@Configuration
+public class TransactionConfig {
+
+  @Bean
+  public TransactionTemplate transactionTemplate(PlatformTransactionManager transactionManager) {
+    TransactionTemplate template = new TransactionTemplate(transactionManager);
+    template.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
+    return template;
+  }
+}

--- a/apps/backend/core/src/main/java/com/cortex/backend/core/common/BusinessErrorCodes.java
+++ b/apps/backend/core/src/main/java/com/cortex/backend/core/common/BusinessErrorCodes.java
@@ -49,6 +49,8 @@ public enum BusinessErrorCodes {
   PAYMENT_FAILED(326, INTERNAL_SERVER_ERROR, "Payment failed"),
   RESOURCE_NOT_FOUND(327, NOT_FOUND, "Resource not found"),
   ALREADY_ENROLLED(328, BAD_REQUEST, "User already enrolled in this roadmap"),
+  EXERCISE_NOT_PUBLISHED(330, BAD_REQUEST, "Exercise is not published"),
+  EXERCISE_NO_LESSON(331, BAD_REQUEST, "Exercise has no lesson assigned"),
   ;
   private final int code;
   private final String description;

--- a/apps/backend/core/src/main/java/com/cortex/backend/core/common/exception/InvalidExerciseStateException.java
+++ b/apps/backend/core/src/main/java/com/cortex/backend/core/common/exception/InvalidExerciseStateException.java
@@ -1,0 +1,14 @@
+package com.cortex.backend.core.common.exception;
+
+import com.cortex.backend.core.common.BusinessErrorCodes;
+import lombok.Getter;
+
+@Getter
+public class InvalidExerciseStateException extends RuntimeException {
+  private final BusinessErrorCodes errorCode;
+
+  public InvalidExerciseStateException(String message, BusinessErrorCodes errorCode) {
+    super(message);
+    this.errorCode = errorCode;
+  }
+}

--- a/apps/backend/core/src/main/java/com/cortex/backend/core/handler/GlobalExceptionHandler.java
+++ b/apps/backend/core/src/main/java/com/cortex/backend/core/handler/GlobalExceptionHandler.java
@@ -36,6 +36,7 @@ import static org.springframework.http.HttpStatus.FORBIDDEN;
 import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 import static org.springframework.http.HttpStatus.UNAUTHORIZED;
 
+import com.cortex.backend.core.common.BusinessErrorCodes;
 import com.cortex.backend.core.common.exception.AlreadyEnrolledException;
 import com.cortex.backend.core.common.exception.CodeExecutionException;
 import com.cortex.backend.core.common.exception.ContainerExecutionException;
@@ -49,6 +50,7 @@ import com.cortex.backend.core.common.exception.GitSyncException;
 import com.cortex.backend.core.common.exception.HashGenerationException;
 import com.cortex.backend.core.common.exception.IncorrectCurrentPasswordException;
 import com.cortex.backend.core.common.exception.InvalidConfigurationException;
+import com.cortex.backend.core.common.exception.InvalidExerciseStateException;
 import com.cortex.backend.core.common.exception.InvalidFileTypeException;
 import com.cortex.backend.core.common.exception.InvalidPrerequisiteException;
 import com.cortex.backend.core.common.exception.InvalidTokenException;
@@ -460,6 +462,19 @@ public class GlobalExceptionHandler {
                 .description(ALREADY_ENROLLED.getDescription())
                 .error(exp.getMessage())
                 .build());
+  }
+
+  @ExceptionHandler(InvalidExerciseStateException.class)
+  public ResponseEntity<ExceptionResponse> handleInvalidExerciseStateException(
+      InvalidExerciseStateException exp) {
+    BusinessErrorCodes errorCode = exp.getErrorCode();
+    return ResponseEntity
+        .status(errorCode.getHttpStatus())
+        .body(ExceptionResponse.builder()
+            .code(errorCode.getCode())
+            .description(errorCode.getDescription())
+            .error(exp.getMessage())
+            .build());
   }
 
 

--- a/apps/backend/education/src/main/java/com/cortex/backend/education/course/api/CourseRepository.java
+++ b/apps/backend/education/src/main/java/com/cortex/backend/education/course/api/CourseRepository.java
@@ -49,4 +49,13 @@ public interface CourseRepository extends CrudRepository<Course, Long> {
       Pageable pageable);
 
   Page<Course> findByRoadmapsContainingOrderByDisplayOrderAsc(Roadmap roadmap, Pageable pageable);
+
+  @Query("""
+        SELECT DISTINCT c FROM Course c
+        LEFT JOIN FETCH c.moduleEntities m
+        LEFT JOIN FETCH m.lessons l
+        LEFT JOIN FETCH l.exercises e
+        WHERE c.id = :courseId
+    """)
+  Optional<Course> findByIdWithDetails(@Param("courseId") Long courseId);
 }

--- a/apps/backend/education/src/main/java/com/cortex/backend/education/course/api/CourseService.java
+++ b/apps/backend/education/src/main/java/com/cortex/backend/education/course/api/CourseService.java
@@ -32,4 +32,5 @@ public interface CourseService {
 
   Long getRoadmapIdForCourse(Long courseId);
   boolean areAllModulesCompleted(Long userId, Long courseId);
+  int getTotalLessons(Long courseId);
 }

--- a/apps/backend/education/src/main/java/com/cortex/backend/education/course/internal/CourseServiceImpl.java
+++ b/apps/backend/education/src/main/java/com/cortex/backend/education/course/internal/CourseServiceImpl.java
@@ -237,5 +237,15 @@ public class CourseServiceImpl implements CourseService {
     return totalModules == completedModules;
   }
 
+  @Override
+  @Transactional(readOnly = true)
+  public int getTotalLessons(Long courseId) {
+    return courseRepository.findById(courseId)
+        .map(course -> course.getModuleEntities().stream()
+            .mapToInt(module -> module.getLessons().size())
+            .sum())
+        .orElse(0);
+  }
+
 
 }

--- a/apps/backend/education/src/main/java/com/cortex/backend/education/exercise/api/ExerciseRelationResolver.java
+++ b/apps/backend/education/src/main/java/com/cortex/backend/education/exercise/api/ExerciseRelationResolver.java
@@ -1,0 +1,7 @@
+package com.cortex.backend.education.exercise.api;
+
+
+public interface ExerciseRelationResolver {
+  Long getLessonIdForExercise(Long exerciseId);
+  boolean areAllExercisesCompletedForLesson(Long userId, Long lessonId);
+}

--- a/apps/backend/education/src/main/java/com/cortex/backend/education/progress/api/ProgressTrackingService.java
+++ b/apps/backend/education/src/main/java/com/cortex/backend/education/progress/api/ProgressTrackingService.java
@@ -1,10 +1,12 @@
 package com.cortex.backend.education.progress.api;
 
 import com.cortex.backend.core.domain.EntityType;
+import com.cortex.backend.core.domain.Lesson;
 import com.cortex.backend.core.domain.UserProgress;
 
 public interface ProgressTrackingService {
   UserProgress trackProgress(Long userId, Long entityId, EntityType entityType);
   void checkAndUpdateParentProgress(Long userId, Long entityId, EntityType entityType);
   boolean isEntityCompleted(Long userId, Long entityId, EntityType entityType);
+  void trackProgressAndCheckCompletion(Long userId, Long exerciseId, EntityType entityType, Lesson lesson);
 }

--- a/apps/backend/education/src/main/java/com/cortex/backend/education/progress/internal/EntityRelationService.java
+++ b/apps/backend/education/src/main/java/com/cortex/backend/education/progress/internal/EntityRelationService.java
@@ -1,0 +1,74 @@
+package com.cortex.backend.education.progress.internal;
+
+import com.cortex.backend.core.domain.EntityType;
+import com.cortex.backend.education.course.api.CourseService;
+import com.cortex.backend.education.exercise.api.ExerciseRelationResolver;
+import com.cortex.backend.education.lesson.api.LessonService;
+import com.cortex.backend.education.module.api.ModuleService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class EntityRelationService {
+
+  private final CourseService courseService;
+  private final ModuleService moduleService;
+  private final LessonService lessonService;
+  private final ExerciseRelationResolver exerciseRelationResolver;
+
+
+  public Long findRelatedRoadmapId(Long entityId, EntityType entityType) {
+    try {
+      return switch (entityType) {
+        case ROADMAP -> entityId;
+        case COURSE -> courseService.getRoadmapIdForCourse(entityId);
+        case MODULE -> {
+          Long courseId = moduleService.getCourseIdForModule(entityId);
+          yield courseService.getRoadmapIdForCourse(courseId);
+        }
+        case LESSON -> {
+          Long moduleId = lessonService.getModuleIdForLesson(entityId);
+          Long courseId = moduleService.getCourseIdForModule(moduleId);
+          yield courseService.getRoadmapIdForCourse(courseId);
+        }
+        case EXERCISE -> {
+          Long lessonId = exerciseRelationResolver.getLessonIdForExercise(entityId);
+          Long moduleId = lessonService.getModuleIdForLesson(lessonId);
+          Long courseId = moduleService.getCourseIdForModule(moduleId);
+          yield courseService.getRoadmapIdForCourse(courseId);
+        }
+        default -> null;
+      };
+    } catch (Exception e) {
+      log.warn("Error finding related roadmap ID for entity {} of type {}: {}",
+          entityId, entityType, e.getMessage());
+      return null;
+    }
+  }
+
+  public Long findRelatedCourseId(Long entityId, EntityType entityType) {
+    try {
+      return switch (entityType) {
+        case COURSE -> entityId;
+        case MODULE -> moduleService.getCourseIdForModule(entityId);
+        case LESSON -> {
+          Long moduleId = lessonService.getModuleIdForLesson(entityId);
+          yield moduleService.getCourseIdForModule(moduleId);
+        }
+        case EXERCISE -> {
+          Long lessonId = exerciseRelationResolver.getLessonIdForExercise(entityId);
+          Long moduleId = lessonService.getModuleIdForLesson(lessonId);
+          yield moduleService.getCourseIdForModule(moduleId);
+        }
+        default -> null;
+      };
+    } catch (Exception e) {
+      log.warn("Error finding related course ID for entity {} of type {}: {}",
+          entityId, entityType, e.getMessage());
+      return null;
+    }
+  }
+}

--- a/apps/backend/education/src/main/java/com/cortex/backend/education/progress/internal/ProgressTrackingServiceImpl.java
+++ b/apps/backend/education/src/main/java/com/cortex/backend/education/progress/internal/ProgressTrackingServiceImpl.java
@@ -1,9 +1,11 @@
 package com.cortex.backend.education.progress.internal;
 
 import com.cortex.backend.core.domain.EntityType;
+import com.cortex.backend.core.domain.Lesson;
 import com.cortex.backend.core.domain.UserProgress;
 import com.cortex.backend.education.achievement.api.AchievementService;
 import com.cortex.backend.education.course.api.CourseService;
+import com.cortex.backend.education.exercise.api.ExerciseRelationResolver;
 import com.cortex.backend.education.lesson.api.LessonService;
 import com.cortex.backend.education.module.api.ModuleService;
 import com.cortex.backend.education.progress.api.LessonCompletedEvent;
@@ -11,23 +13,55 @@ import com.cortex.backend.education.progress.api.ProgressTrackingService;
 import com.cortex.backend.education.progress.api.ProgressUpdatedEvent;
 import com.cortex.backend.education.progress.api.UserProgressService;
 import com.cortex.backend.education.roadmap.api.RoadmapService;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.CacheManager;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class ProgressTrackingServiceImpl implements ProgressTrackingService {
-
   private final UserProgressService userProgressService;
   private final AchievementService achievementService;
+  private final EntityRelationService entityRelationService;
+  private final ExerciseRelationResolver exerciseRelationResolver;
   private final ApplicationEventPublisher eventPublisher;
   private final LessonService lessonService;
   private final ModuleService moduleService;
   private final CourseService courseService;
   private final RoadmapService roadmapService;
+  private final CacheManager cacheManager;
+
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
+  public void trackProgressAndCheckCompletion(Long userId, Long exerciseId, EntityType entityType, Lesson lesson) {
+    try {
+      UserProgress progress = trackProgress(userId, exerciseId, entityType);
+
+      if (lesson != null) {
+        if (exerciseRelationResolver.areAllExercisesCompletedForLesson(userId, lesson.getId())) {
+          eventPublisher.publishEvent(new LessonCompletedEvent(lesson.getId(), userId));
+        }
+      } else {
+        log.debug("Exercise {} has no associated lesson, skipping lesson completion check", exerciseId);
+      }
+    } catch (Exception e) {
+      log.error("Error tracking progress for exercise {} and user {}: {}",
+          exerciseId, userId, e.getMessage());
+      throw e;
+    }
+  }
+
+  private void validateExerciseState(Long exerciseId, Lesson lesson) {
+    if (lesson == null) {
+      log.warn("Exercise {} has no associated lesson", exerciseId);
+    }
+  }
 
   @Override
   @Transactional
@@ -35,12 +69,34 @@ public class ProgressTrackingServiceImpl implements ProgressTrackingService {
     UserProgress progress = userProgressService.saveProgress(userId, entityId, entityType);
     checkAndUpdateParentProgress(userId, entityId, entityType);
     checkAndAwardAchievements(userId, entityType);
-    eventPublisher.publishEvent(new ProgressUpdatedEvent(userId, entityId, entityType));
+
+    // Publishing event for progress update
+    ProgressUpdatedEvent event = new ProgressUpdatedEvent(userId, entityId, entityType);
+    eventPublisher.publishEvent(event);
+
+    // Invalidating related caches
+    invalidateRelatedCaches(entityId, entityType);
 
     return progress;
   }
 
+  private void invalidateRelatedCaches(Long entityId, EntityType entityType) {
+    try {
+      Long roadmapId = entityRelationService.findRelatedRoadmapId(entityId, entityType);
+      if (roadmapId != null) {
+        Optional.ofNullable(cacheManager.getCache("roadmaps"))
+            .ifPresent(cache -> {
+              cache.evict(roadmapId);
+              log.debug("Invalidated cache for roadmap ID: {}", roadmapId);
+            });
+      }
+    } catch (Exception e) {
+      log.error("Error invalidating caches for entity: {} of type: {}", entityId, entityType, e);
+    }
+  }
+
   @Override
+  @Transactional
   public void checkAndUpdateParentProgress(Long userId, Long entityId, EntityType entityType) {
     switch (entityType) {
       case LESSON:
@@ -80,8 +136,7 @@ public class ProgressTrackingServiceImpl implements ProgressTrackingService {
       trackProgress(userId, roadmapId, EntityType.ROADMAP);
     }
   }
-  
-  
+
   @EventListener
   @Transactional
   public void handleLessonCompletedEvent(LessonCompletedEvent event) {

--- a/apps/backend/education/src/main/java/com/cortex/backend/education/roadmap/internal/RoadmapEnrollmentService.java
+++ b/apps/backend/education/src/main/java/com/cortex/backend/education/roadmap/internal/RoadmapEnrollmentService.java
@@ -2,35 +2,58 @@ package com.cortex.backend.education.roadmap.internal;
 
 import com.cortex.backend.core.common.exception.AlreadyEnrolledException;
 import com.cortex.backend.core.common.exception.ResourceNotFoundException;
+import com.cortex.backend.core.domain.Course;
 import com.cortex.backend.core.domain.EnrollmentStatus;
 import com.cortex.backend.core.domain.EntityType;
+import com.cortex.backend.core.domain.Exercise;
+import com.cortex.backend.core.domain.Lesson;
+import com.cortex.backend.core.domain.ModuleEntity;
 import com.cortex.backend.core.domain.RoadmapEnrollment;
 import com.cortex.backend.core.domain.RoadmapEnrollmentId;
+import com.cortex.backend.education.course.api.CourseRepository;
 import com.cortex.backend.education.course.api.CourseService;
 import com.cortex.backend.education.course.api.dto.CourseResponse;
 import com.cortex.backend.education.progress.api.ProgressTrackingService;
+import com.cortex.backend.education.progress.api.ProgressUpdatedEvent;
 import com.cortex.backend.education.progress.api.RoadmapEnrollmentEvent;
+import com.cortex.backend.education.progress.api.UserProgressService;
+import com.cortex.backend.education.progress.internal.EntityRelationService;
 import com.cortex.backend.education.roadmap.api.RoadmapEnrollmentRepository;
 import com.cortex.backend.education.roadmap.api.RoadmapService;
 import com.cortex.backend.education.roadmap.api.dto.RoadmapEnrollmentResponse;
 import com.cortex.backend.education.roadmap.api.dto.RoadmapResponse;
-import jakarta.transaction.Transactional;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class RoadmapEnrollmentService {
 
   private final RoadmapEnrollmentRepository enrollmentRepository;
   private final CourseService courseService;
+  private final CourseRepository courseRepository;
   private final RoadmapService roadmapService;
   private final ProgressTrackingService progressTrackingService;
+  private final TransactionTemplate transactionTemplate;
+  private final UserProgressService userProgressService;
   private final ApplicationEventPublisher eventPublisher;
   private final RoadmapEnrollmentMapper enrollmentMapper;
+  private final EntityRelationService entityRelationService;
+
+  private static final String PROGRESS_CACHE = "roadmap-progress";
 
   @Transactional
   public RoadmapEnrollmentResponse enrollUserInRoadmap(Long userId, Long roadmapId) {
@@ -49,36 +72,164 @@ public class RoadmapEnrollmentService {
     enrollment = enrollmentRepository.save(enrollment);
     eventPublisher.publishEvent(new RoadmapEnrollmentEvent(userId, roadmapId));
 
-    double progress = calculateRoadmapProgress(userId, roadmapId);
+    double progress = getProgress(userId, roadmapId);
     return enrollmentMapper.toResponse(enrollment, progress);
   }
 
   public List<RoadmapEnrollmentResponse> getUserEnrollments(Long userId) {
     return enrollmentRepository.findByIdUserId(userId).stream()
         .map(enrollment -> {
-          double progress = calculateRoadmapProgress(userId, enrollment.getId().getRoadmapId());
+          double progress = calculateRoadmapProgress(
+              userId,
+              enrollment.getId().getRoadmapId()
+          );
           return enrollmentMapper.toResponse(enrollment, progress);
         })
         .toList();
   }
 
-  public double calculateRoadmapProgress(Long userId, Long roadmapId) {
-    RoadmapResponse roadmap = roadmapService.getRoadmapById(roadmapId)
-        .orElseThrow(() -> new ResourceNotFoundException("Roadmap not found"));
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
+  protected void updateEnrollmentStatusInternal(Long userId, Long roadmapId,
+      EnrollmentStatus newStatus) {
+    RoadmapEnrollmentId enrollmentId = new RoadmapEnrollmentId(userId, roadmapId);
+    enrollmentRepository.findById(enrollmentId)
+        .ifPresent(enrollment -> {
+          enrollment.setStatus(newStatus);
+          enrollment.setLastActivityDate(LocalDateTime.now());
+          enrollmentRepository.save(enrollment);
+        });
+  }
 
-    long totalCourses = roadmap.getCourseSlugs().size();
-    if (totalCourses == 0) {
-      return 0.0;
+  public RoadmapEnrollmentResponse updateEnrollmentStatus(Long userId, Long roadmapId,
+      EnrollmentStatus newStatus) {
+    updateEnrollmentStatusInternal(userId, roadmapId, newStatus);
+    double progress = getProgress(userId, roadmapId);
+    return enrollmentMapper.toResponse(
+        enrollmentRepository.findById(new RoadmapEnrollmentId(userId, roadmapId))
+            .orElseThrow(() -> new ResourceNotFoundException("Enrollment not found")),
+        progress
+    );
+  }
+
+  @Transactional
+  public void updateLastActivityDate(Long userId, Long roadmapId) {
+    RoadmapEnrollmentId enrollmentId = new RoadmapEnrollmentId(userId, roadmapId);
+    enrollmentRepository.findById(enrollmentId)
+        .ifPresent(enrollment -> {
+          enrollment.setLastActivityDate(LocalDateTime.now());
+          enrollmentRepository.save(enrollment);
+        });
+  }
+
+  @EventListener
+  public void handleEnrollmentUpdate(ProgressUpdatedEvent event) {
+    Long roadmapId = entityRelationService.findRelatedRoadmapId(
+        event.entityId(),
+        event.entityType()
+    );
+
+    if (roadmapId != null) {
+      transactionTemplate.execute(status -> {
+        try {
+          updateLastActivityDate(event.userId(), roadmapId);
+          double progress = getProgress(event.userId(), roadmapId);
+          if (progress >= 100.0) {
+            updateEnrollmentStatus(event.userId(), roadmapId, EnrollmentStatus.COMPLETED);
+          }
+          return null;
+        } catch (Exception e) {
+          status.setRollbackOnly();
+          log.error("Error handling enrollment update", e);
+          return null;
+        }
+      });
+    }
+  }
+
+  private double getProgress(Long userId, Long roadmapId) {
+    return calculateRoadmapProgress(userId, roadmapId);
+  }
+
+
+  @Cacheable(value = PROGRESS_CACHE, key = "{#userId, #roadmapId}")
+  public double calculateRoadmapProgress(Long userId, Long roadmapId) {
+    Double result = transactionTemplate.execute(_ -> {
+      try {
+        RoadmapResponse roadmap = roadmapService.getRoadmapById(roadmapId)
+            .orElseThrow(() -> new ResourceNotFoundException("Roadmap not found"));
+
+        if (roadmap.getCourseSlugs().isEmpty()) {
+          return 0.0;
+        }
+
+        double totalCredits = 0.0;
+        double earnedCredits = 0.0;
+
+        for (String courseSlug : roadmap.getCourseSlugs()) {
+          Optional<CourseResponse> courseOpt = courseService.getCourseBySlug(courseSlug);
+          if (courseOpt.isPresent()) {
+            CourseCredits courseCredits = calculateCourseCredits(userId, courseOpt.get().getId());
+            totalCredits += courseCredits.total();
+            earnedCredits += courseCredits.earned();
+          }
+        }
+
+        return totalCredits > 0 ? (earnedCredits / totalCredits) * 100 : 0.0;
+      } catch (Exception e) {
+        log.error("Error calculating roadmap progress for user {} and roadmap {}",
+            userId, roadmapId, e);
+        return 0.0;
+      }
+    });
+    return result != null ? result : 0.0;
+  }
+
+  @CacheEvict(value = PROGRESS_CACHE, key = "{#userId, #roadmapId}")
+  public void evictProgressCache(Long userId, Long roadmapId) {
+    log.debug("Evicted progress cache for user {} and roadmap {}", userId, roadmapId);
+  }
+
+  private record CourseCredits(double earned, double total) {
+
+  }
+
+  private CourseCredits calculateCourseCredits(Long userId, Long courseId) {
+    double totalCredits = 0.0;
+    double earnedCredits = 0.0;
+
+    Course course = courseRepository.findByIdWithDetails(courseId)
+        .orElseThrow(() -> new ResourceNotFoundException("Course not found"));
+
+    for (ModuleEntity module : course.getModuleEntities()) {
+      for (Lesson lesson : module.getLessons()) {
+        double lessonCredits = lesson.getCredits();
+        totalCredits += lessonCredits;
+
+        if (userProgressService.isEntityCompleted(userId, lesson.getId(), EntityType.LESSON)) {
+          earnedCredits += lessonCredits;
+        }
+
+        for (Exercise exercise : lesson.getExercises()) {
+          double exercisePoints = exercise.getPoints();
+          totalCredits += exercisePoints;
+
+          if (userProgressService.isEntityCompleted(userId, exercise.getId(),
+              EntityType.EXERCISE)) {
+            earnedCredits += exercisePoints;
+          }
+        }
+      }
     }
 
-    long completedCourses = roadmap.getCourseSlugs().stream()
-        .map(slug -> courseService.getCourseBySlug(slug)
-            .map(CourseResponse::getId)
-            .orElse(null))
-        .filter(courseId -> courseId != null &&
-            progressTrackingService.isEntityCompleted(userId, courseId, EntityType.COURSE))
-        .count();
+    return new CourseCredits(earnedCredits, totalCredits);
+  }
 
-    return (double) completedCourses / totalCourses * 100;
+  @EventListener
+  public void handleProgressUpdated(ProgressUpdatedEvent event) {
+    Long roadmapId = entityRelationService.findRelatedRoadmapId(event.entityId(),
+        event.entityType());
+    if (roadmapId != null) {
+      evictProgressCache(event.userId(), roadmapId);
+    }
   }
 }

--- a/apps/backend/engine/src/main/java/com/cortex/backend/engine/internal/ExerciseRelationResolverImpl.java
+++ b/apps/backend/engine/src/main/java/com/cortex/backend/engine/internal/ExerciseRelationResolverImpl.java
@@ -1,0 +1,27 @@
+package com.cortex.backend.engine.internal;
+
+import com.cortex.backend.education.exercise.api.ExerciseRelationResolver;
+import com.cortex.backend.engine.api.ExerciseRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ExerciseRelationResolverImpl implements ExerciseRelationResolver {
+  private final ExerciseRepository exerciseRepository;
+
+  @Override
+  @Transactional(readOnly = true)
+  public Long getLessonIdForExercise(Long exerciseId) {
+    return exerciseRepository.findById(exerciseId)
+        .map(exercise -> exercise.getLesson().getId())
+        .orElse(null);
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public boolean areAllExercisesCompletedForLesson(Long userId, Long lessonId) {
+    return exerciseRepository.areAllExercisesCompletedForLesson(userId, lessonId);
+  }
+}


### PR DESCRIPTION
The changes in this commit include:

1. Added a new method `trackProgressAndCheckCompletion` in the `ProgressTrackingService` interface to track the progress of a user for a given exercise and check if the lesson is completed.

2. Created a new interface `ExerciseRelationResolver` with methods to get the lesson ID for a given exercise and check if all exercises for a lesson are completed by a user.

3. Refactored the `EngineController` to handle exceptions more gracefully and return appropriate HTTP status codes.

4. Removed the unused `@Transactional` annotation from the `Application` class.

5. Added a new `TransactionConfig` class to configure a `TransactionTemplate` with a `REQUIRES_NEW` propagation behavior.