### PR TITLE
feat(auth): Add GitHub OAuth2 scopes for email and user info

### DIFF
--- a/apps/backend/app/src/main/resources/application-dev.yml
+++ b/apps/backend/app/src/main/resources/application-dev.yml
@@ -33,6 +33,9 @@ spring:
           github:
             client-id: ${GITHUB_CLIENT_ID}
             client-secret: ${GITHUB_CLIENT_SECRET}
+            scope:
+              - user:email
+              - read:user
   ai:
     ollama:
       init:


### PR DESCRIPTION
Adds the `user:email` and `read:user` scopes to the GitHub OAuth2
configuration. This allows the application to retrieve the user's email
address and basic profile information during the authentication flow.