### PR TITLE
feat(chat): Add username to chat stream and improve chat memory

### DIFF
--- a/apps/backend/chat/src/main/java/com/cortex/backend/chat/api/AiChatController.java
+++ b/apps/backend/chat/src/main/java/com/cortex/backend/chat/api/AiChatController.java
@@ -1,6 +1,7 @@
 package com.cortex.backend.chat.api;
 
 import com.cortex.backend.chat.internal.AiChatService;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -20,7 +21,7 @@ public class AiChatController {
   @GetMapping
   public Flux<String> chatWithStream(@RequestParam String message,
       @RequestParam String exerciseSlug,
-      @RequestParam(required = false) String userCode) {
-    return aiChatService.getChatStream(message, exerciseSlug, userCode);
+      @RequestParam(required = false) String userCode, Authentication authentication) {
+    return aiChatService.getChatStream(message, exerciseSlug, userCode, authentication.getName());
   }
 }

--- a/apps/backend/chat/src/main/java/com/cortex/backend/chat/config/AiConfig.java
+++ b/apps/backend/chat/src/main/java/com/cortex/backend/chat/config/AiConfig.java
@@ -2,6 +2,7 @@ package com.cortex.backend.chat.config;
 
 import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.ai.chat.client.advisor.MessageChatMemoryAdvisor;
+import org.springframework.ai.chat.client.advisor.PromptChatMemoryAdvisor;
 import org.springframework.ai.chat.memory.InMemoryChatMemory;
 import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.context.annotation.Bean;
@@ -13,8 +14,11 @@ public class AiConfig {
 
   @Bean
   public ChatClient chatClient(ChatModel chatModel) {
+    InMemoryChatMemory memory = new InMemoryChatMemory();
     return ChatClient.builder(chatModel)
-        .defaultAdvisors(new MessageChatMemoryAdvisor(new InMemoryChatMemory()))
+        .defaultAdvisors(
+            new PromptChatMemoryAdvisor(memory),
+            new MessageChatMemoryAdvisor(memory))
         .build();
   }
 }

--- a/bruno/Exercise/Result.bru
+++ b/bruno/Exercise/Result.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 get {
-  url: {{BASEURL}}/api/v1/engine/result/59d6dae5-f7f4-4269-8746-d08b5cba106d
+  url: {{BASEURL}}/api/v1/engine/result/2996df2b-7746-49a2-ad5c-c4932d582208
   body: none
   auth: bearer
 }


### PR DESCRIPTION
The changes made in this commit include:

1. Modify the `getChatStream` method in `AiChatService` to accept a `username` parameter, which is used to identify the conversation in the chat memory.
2. Update the `ChatClient` configuration in `AiConfig` to use the `PromptChatMemoryAdvisor` in addition to the `MessageChatMemoryAdvisor`. This allows the chat memory to be used for both the user's messages and the AI's responses.
3. Enhance the chat memory configuration by setting the `CHAT_MEMORY_CONVERSATION_ID_KEY` to the `username` and the `CHAT_MEMORY_RETRIEVE_SIZE_KEY` to 100, which determines the number of previous messages to consider in the chat memory.

These changes aim to improve the chat experience by maintaining a conversation context and allowing the AI to provide more relevant and coherent responses based on the chat history.