### PR TITLE
fix(chat): Remove username parameter from getChatStream

### DIFF
--- a/apps/backend/chat/src/main/java/com/cortex/backend/chat/api/AiChatController.java
+++ b/apps/backend/chat/src/main/java/com/cortex/backend/chat/api/AiChatController.java
@@ -1,7 +1,6 @@
 package com.cortex.backend.chat.api;
 
 import com.cortex.backend.chat.internal.AiChatService;
-import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -21,7 +20,7 @@ public class AiChatController {
   @GetMapping
   public Flux<String> chatWithStream(@RequestParam String message,
       @RequestParam String exerciseSlug,
-      @RequestParam(required = false) String userCode, Authentication authentication) {
-    return aiChatService.getChatStream(message, exerciseSlug, userCode, authentication.getName());
+      @RequestParam(required = false) String userCode) {
+    return aiChatService.getChatStream(message, exerciseSlug, userCode);
   }
 }

--- a/apps/backend/chat/src/main/java/com/cortex/backend/chat/internal/AiChatService.java
+++ b/apps/backend/chat/src/main/java/com/cortex/backend/chat/internal/AiChatService.java
@@ -26,8 +26,7 @@ public class AiChatService {
   private final ChatClient chatClient;
   private final ExerciseService exerciseService;
 
-  public Flux<String> getChatStream(String message, String exerciseSlug, String userCode,
-      String username) {
+  public Flux<String> getChatStream(String message, String exerciseSlug, String userCode) {
     Optional<ExerciseResponse> exercise = exerciseService.getExerciseBySlug(exerciseSlug);
 
     if (exercise.isEmpty()) {
@@ -41,7 +40,7 @@ public class AiChatService {
         .system(exercisePrompt)
         .user(message)
         .advisors(a -> a
-            .param(CHAT_MEMORY_CONVERSATION_ID_KEY, username)
+            .param(CHAT_MEMORY_CONVERSATION_ID_KEY, exerciseSlug)
             .param(CHAT_MEMORY_RETRIEVE_SIZE_KEY, 100)
         )
         .stream()


### PR DESCRIPTION
Removes the `username` parameter from the `getChatStream` method in the
`AiChatService` class. The `username` parameter was previously used to set
the `CHAT_MEMORY_CONVERSATION_ID_KEY` parameter in the chat client, but
this has been changed to use the `exerciseSlug` instead. This change
simplifies the method signature and removes the need to pass the
`Authentication` object from the controller to the service.