### PR TITLE
feat(lesson): add user progress to lesson response

### DIFF
--- a/apps/backend/education/src/main/java/com/cortex/backend/education/achievement/internal/AchievementProcessorServiceImpl.java
+++ b/apps/backend/education/src/main/java/com/cortex/backend/education/achievement/internal/AchievementProcessorServiceImpl.java
@@ -58,7 +58,7 @@ public class AchievementProcessorServiceImpl implements AchievementProcessorServ
   }
 
   private void processLessonAchievements(Long userId, Long lessonId) {
-    Optional<LessonResponse> lesson = lessonService.getLessonById(lessonId);
+    Optional<LessonResponse> lesson = lessonService.getLessonById(lessonId, userId);
     if (lesson.isPresent()) {
       awardAchievementIfNotExists(userId, "COMPLETE_FIRST_LESSON");
       checkAllLessonsInModuleCompleted(userId, lesson.get().getModuleId());

--- a/apps/backend/education/src/main/java/com/cortex/backend/education/lesson/api/LessonController.java
+++ b/apps/backend/education/src/main/java/com/cortex/backend/education/lesson/api/LessonController.java
@@ -1,6 +1,7 @@
 package com.cortex.backend.education.lesson.api;
 
 import com.cortex.backend.core.common.PageResponse;
+import com.cortex.backend.core.domain.User;
 import com.cortex.backend.education.lesson.api.dto.LessonRequest;
 import com.cortex.backend.education.lesson.api.dto.LessonResponse;
 import com.cortex.backend.education.lesson.api.dto.LessonUpdateRequest;
@@ -14,6 +15,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -39,9 +41,11 @@ public class LessonController {
   public ResponseEntity<PageResponse<LessonResponse>> getAllPublishedLessons(
       @RequestParam(name = "page", defaultValue = "0") int page,
       @RequestParam(name = "size", defaultValue = "10") int size,
-      @RequestParam(name = "sort", required = false) String[] sort
+      @RequestParam(name = "sort", required = false) String[] sort,
+      Authentication authentication
   ) {
-    return ResponseEntity.ok(lessonService.getAllPublishedLessons(page, size, sort));
+    Long userId = authentication != null ? ((User) authentication.getPrincipal()).getId() : null;
+    return ResponseEntity.ok(lessonService.getAllPublishedLessons(page, size, sort, userId));
   }
 
   @GetMapping("/admin")
@@ -52,9 +56,11 @@ public class LessonController {
   public ResponseEntity<PageResponse<LessonResponse>> getAllLessons(
       @RequestParam(name = "page", defaultValue = "0") int page,
       @RequestParam(name = "size", defaultValue = "10") int size,
-      @RequestParam(name = "sort", required = false) String[] sort
+      @RequestParam(name = "sort", required = false) String[] sort,
+      Authentication authentication
   ) {
-    return ResponseEntity.ok(lessonService.getAllLessons(page, size, sort));
+    Long userId = authentication != null ? ((User) authentication.getPrincipal()).getId() : null;
+    return ResponseEntity.ok(lessonService.getAllLessons(page, size, sort, userId));
   }
 
   @GetMapping("/{id}")
@@ -62,8 +68,12 @@ public class LessonController {
   @ApiResponse(responseCode = "200", description = "Successful operation",
       content = @Content(schema = @Schema(implementation = LessonResponse.class)))
   @ApiResponse(responseCode = "404", description = "Lesson not found")
-  public ResponseEntity<LessonResponse> getLessonById(@PathVariable Long id) {
-    return lessonService.getLessonById(id)
+  public ResponseEntity<LessonResponse> getLessonById(
+      @PathVariable Long id,
+      Authentication authentication
+  ) {
+    Long userId = authentication != null ? ((User) authentication.getPrincipal()).getId() : null;
+    return lessonService.getLessonById(id, userId)
         .map(ResponseEntity::ok)
         .orElse(ResponseEntity.notFound().build());
   }
@@ -73,11 +83,16 @@ public class LessonController {
   @ApiResponse(responseCode = "200", description = "Successful operation",
       content = @Content(schema = @Schema(implementation = LessonResponse.class)))
   @ApiResponse(responseCode = "404", description = "Lesson not found")
-  public ResponseEntity<LessonResponse> getLessonBySlug(@PathVariable String slug) {
-    return lessonService.getLessonBySlug(slug)
+  public ResponseEntity<LessonResponse> getLessonBySlug(
+      @PathVariable String slug,
+      Authentication authentication
+  ) {
+    Long userId = authentication != null ? ((User) authentication.getPrincipal()).getId() : null;
+    return lessonService.getLessonBySlug(slug, userId)
         .map(ResponseEntity::ok)
         .orElse(ResponseEntity.notFound().build());
   }
+
 
   @PostMapping
   @PreAuthorize("hasAnyRole('MODERATOR', 'ADMIN')")

--- a/apps/backend/education/src/main/java/com/cortex/backend/education/lesson/api/LessonService.java
+++ b/apps/backend/education/src/main/java/com/cortex/backend/education/lesson/api/LessonService.java
@@ -9,22 +9,22 @@ import org.springframework.data.domain.Page;
 
 public interface LessonService {
 
-  PageResponse<LessonResponse> getAllPublishedLessons(int page, int size, String[] sort);
+  PageResponse<LessonResponse> getAllPublishedLessons(int page, int size, String[] sort,
+      Long userId);
 
-  PageResponse<LessonResponse> getAllLessons(int page, int size, String[] sort);
+  PageResponse<LessonResponse> getAllLessons(int page, int size, String[] sort, Long userId);
 
-  Optional<LessonResponse> getLessonById(Long id);
+  Optional<LessonResponse> getLessonById(Long id, Long userId);
 
-  Optional<LessonResponse> getLessonBySlug(String slug);
+  Optional<LessonResponse> getLessonBySlug(String slug, Long userId);
 
-  LessonResponse createLesson(LessonRequest lesson);
+  LessonResponse createLesson(LessonRequest request);
 
-  LessonResponse updateLesson(Long id, LessonUpdateRequest lessonRequest);
+  LessonResponse updateLesson(Long id, LessonUpdateRequest request);
 
   void deleteLesson(Long id);
 
   void completeLesson(Long lessonId, Long userId);
-  
+
   Long getModuleIdForLesson(Long lessonId);
-  
 }

--- a/apps/backend/education/src/main/java/com/cortex/backend/education/lesson/api/dto/ExerciseInfo.java
+++ b/apps/backend/education/src/main/java/com/cortex/backend/education/lesson/api/dto/ExerciseInfo.java
@@ -1,0 +1,20 @@
+package com.cortex.backend.education.lesson.api.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ExerciseInfo {
+  private Long id;
+  private String slug;
+  private String title;
+  @JsonProperty("is_completed")
+  private boolean isCompleted;
+  private int points;
+}

--- a/apps/backend/education/src/main/java/com/cortex/backend/education/lesson/api/dto/LessonResponse.java
+++ b/apps/backend/education/src/main/java/com/cortex/backend/education/lesson/api/dto/LessonResponse.java
@@ -28,8 +28,7 @@ public class LessonResponse {
   @JsonProperty("module_name")
   private String moduleName;
 
-  @JsonProperty("exercise_ids")
-  private Set<Long> exerciseIds;
+  private Set<ExerciseInfo> exercises;
 
   @JsonProperty("created_at")
   private LocalDateTime createdAt;


### PR DESCRIPTION
The changes made in this commit include:

1. Added the `Authentication` parameter to the `getLessonById` and `getLessonBySlug` methods in the `LessonController` class. This allows the controller to retrieve the user's ID from the authentication object and pass it to the service layer.

2. Updated the `getLessonById` and `getLessonBySlug` methods in the `LessonServiceImpl` class to accept the user ID and use it to retrieve the user's progress for the lesson.

3. Modified the `toLessonResponse` method in the `LessonMapper` interface to include the user's progress for the lesson.

4. Added the `getUserProgress` method to the `LessonResponse` class to retrieve the user's progress for the lesson.

These changes were made to enhance the lesson response by including the user's progress for the lesson, which is useful for displaying the user's progress in the frontend application.