### PR TITLE
feat(roadmaps): enroll funcionality

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ reqwest = { version = "0.12.9", features = ["json", "multipart"] }
 thiserror = "2.0.1"
 anyhow = "1.0.93"
 tokio = { version = "1.41.1", features = ["full"] }
+chrono = { version = "0.4", features = ["serde"] }
 
 [profile.dev]
 incremental = true # Compile your binary in smaller steps.

--- a/apps/backend/education/src/main/java/com/cortex/backend/education/lesson/api/dto/ExerciseInfo.java
+++ b/apps/backend/education/src/main/java/com/cortex/backend/education/lesson/api/dto/ExerciseInfo.java
@@ -11,10 +11,13 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @Builder
 public class ExerciseInfo {
+
   private Long id;
   private String slug;
   private String title;
   @JsonProperty("is_completed")
   private boolean isCompleted;
   private int points;
+  @JsonProperty("display_order")
+  private int displayOrder;
 }

--- a/apps/backend/education/src/main/java/com/cortex/backend/education/lesson/internal/LessonMapper.java
+++ b/apps/backend/education/src/main/java/com/cortex/backend/education/lesson/internal/LessonMapper.java
@@ -40,6 +40,7 @@ public interface LessonMapper {
             .slug(exercise.getSlug())
             .title(exercise.getTitle())
             .points(exercise.getPoints())
+            .displayOrder(exercise.getDisplayOrder())
             .isCompleted(userProgressService.isEntityCompleted(
                 userId,
                 exercise.getId(),

--- a/apps/desktop/src-tauri/crates/education/Cargo.toml
+++ b/apps/desktop/src-tauri/crates/education/Cargo.toml
@@ -10,5 +10,6 @@ reqwest = { workspace = true }
 tokio = {workspace = true}
 tauri = {workspace = true}
 serde_json = {workspace = true}
+chrono = {workspace = true}
 error = {path = "../error"}
 common = {path = "../common"}

--- a/apps/desktop/src-tauri/crates/education/src/lib.rs
+++ b/apps/desktop/src-tauri/crates/education/src/lib.rs
@@ -4,7 +4,17 @@ pub mod lessons;
 pub mod modules;
 pub mod roadmaps;
 
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum EnrollmentStatus {
+    Active,
+    Paused,
+    Dropped,
+    Completed,
+}
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct PaginatedResponse<T> {
@@ -83,6 +93,8 @@ pub struct ExerciseInfo {
     #[serde(rename = "is_completed")]
     pub is_completed: bool,
     pub points: u32,
+    #[serde(rename = "display_order")]
+    pub display_order: i32,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -92,11 +104,30 @@ pub struct Roadmap {
     pub description: String,
     pub slug: String,
     pub image_url: Option<String>,
-    pub tag_names: Option<Vec<String>>,  
+    pub tag_names: Option<Vec<String>>,
     pub is_published: bool,
-    pub course_slugs: Option<Vec<String>>,  
+    pub course_slugs: Option<Vec<String>>,
     pub created_at: String,
     pub updated_at: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct RoadmapEnrollmentResponse {
+    #[serde(rename = "user_id")]
+    pub user_id: u64,
+
+    #[serde(rename = "roadmap_id")]
+    pub roadmap_id: u64,
+
+    #[serde(rename = "enrollment_date")]
+    pub enrollment_date: DateTime<Utc>,
+
+    pub status: EnrollmentStatus,
+
+    #[serde(rename = "last_activity_date")]
+    pub last_activity_date: DateTime<Utc>,
+
+    pub progress: f64,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/apps/desktop/src-tauri/crates/education/src/roadmaps/commands/mod.rs
+++ b/apps/desktop/src-tauri/crates/education/src/roadmaps/commands/mod.rs
@@ -2,7 +2,7 @@ use crate::roadmaps::{
     create_roadmap, delete_roadmap, fetch_course_from_roadmap, fetch_roadmaps,
     fetch_roadmaps_details, update_roadmap,
 };
-use crate::{roadmaps, Course, CourseAssignment, PaginatedResponse, PaginatedRoadmaps, Roadmap, RoadmapCourseAssignment, RoadmapCreateRequest, RoadmapDetails, RoadmapUpdateRequest};
+use crate::{roadmaps, Course, CourseAssignment, PaginatedResponse, PaginatedRoadmaps, Roadmap, RoadmapCourseAssignment, RoadmapCreateRequest, RoadmapDetails, RoadmapEnrollmentResponse, RoadmapUpdateRequest};
 use common::handle_content_image_upload;
 use common::state::AppState;
 use error::AppError;
@@ -153,7 +153,9 @@ pub async fn get_available_courses(
     state: State<'_, AppState>,
 ) -> Result<PaginatedResponse<Course>, AppError> {
     debug!("Fetching available courses for roadmap: {}", roadmap_id);
-    match roadmaps::get_available_courses(roadmap_id, state, page, size, sort, include_unpublished).await {
+    match roadmaps::get_available_courses(roadmap_id, state, page, size, sort, include_unpublished)
+        .await
+    {
         Ok(paginated_courses) => {
             debug!("Successfully fetched {} available courses", paginated_courses.content.len());
             Ok(paginated_courses)
@@ -183,4 +185,12 @@ pub async fn update_roadmap_courses(
             Err(e)
         }
     }
+}
+
+#[tauri::command]
+pub async fn enroll_in_roadmap(
+    roadmap_id: u64,
+    state: State<'_, AppState>,
+) -> Result<RoadmapEnrollmentResponse, AppError> {
+    super::enroll_in_roadmap(roadmap_id, state).await
 }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -118,7 +118,8 @@ pub fn run() {
             education::roadmaps::commands::delete_roadmap_command,
             education::roadmaps::commands::get_roadmap_courses,
             education::roadmaps::commands::get_available_courses,
-             education::roadmaps::commands::update_roadmap_courses,
+            education::roadmaps::commands::update_roadmap_courses,
+            education::roadmaps::commands::enroll_in_roadmap,
             
             // Courses
             education::courses::commands::fetch_all_courses,


### PR DESCRIPTION
## Description

This pull request includes the following changes:

1. **Add display order to exercise info**: Adds a new `displayOrder` field to the `ExerciseInfo` DTO to represent the order in which the exercises should be displayed. This change is necessary to ensure the exercises are presented to the user in the correct order.

2. **Add chrono dependency**: The changes in this commit add the `chrono` dependency to the `education` crate in the Tauri desktop application. This dependency is required to handle date and time-related functionality within the application.

3. **Add enroll_in_roadmap command**: This commit adds a new Tauri command `enroll_in_roadmap` to the education module. This command allows users to enroll in a specific roadmap by providing the roadmap ID.

   The changes include:
   - Adding a new `RoadmapEnrollmentResponse` struct to the `education` module to represent the response from the enrollment API.
   - Implementing the `enroll_in_roadmap` function in the `roadmaps` module to handle the enrollment process.
   - Registering the new `enroll_in_roadmap` command in the `run` function of the main `lib.rs` file.