### PR TITLE
feat(roadmap): add  get_user_enrollments command

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ resolver = "2"
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 log = "0.4.22"
-tauri = { version = "2.1.1", features = ["protocol-asset"] }
+tauri = { version = "2.1.1", features = ["protocol-asset", "test"] }
 tauri-plugin-shell = "2.0.2"
 tauri-plugin-oauth = "2"
 tauri-plugin-store = "2.1.0"

--- a/apps/desktop/src-tauri/crates/education/src/roadmaps/commands/mod.rs
+++ b/apps/desktop/src-tauri/crates/education/src/roadmaps/commands/mod.rs
@@ -1,8 +1,9 @@
-use crate::roadmaps::{
-    create_roadmap, delete_roadmap, fetch_course_from_roadmap, fetch_roadmaps,
-    fetch_roadmaps_details, update_roadmap,
+use crate::roadmaps::*;
+use crate::{
+    roadmaps, Course, CourseAssignment, PaginatedResponse, PaginatedRoadmaps, Roadmap,
+    RoadmapCourseAssignment, RoadmapCreateRequest, RoadmapDetails, RoadmapEnrollmentResponse,
+    RoadmapUpdateRequest,
 };
-use crate::{roadmaps, Course, CourseAssignment, PaginatedResponse, PaginatedRoadmaps, Roadmap, RoadmapCourseAssignment, RoadmapCreateRequest, RoadmapDetails, RoadmapEnrollmentResponse, RoadmapUpdateRequest};
 use common::handle_content_image_upload;
 use common::state::AppState;
 use error::AppError;
@@ -193,4 +194,21 @@ pub async fn enroll_in_roadmap(
     state: State<'_, AppState>,
 ) -> Result<RoadmapEnrollmentResponse, AppError> {
     super::enroll_in_roadmap(roadmap_id, state).await
+}
+
+#[tauri::command]
+pub async fn get_user_enrollments(
+    state: State<'_, AppState>,
+) -> Result<Vec<RoadmapEnrollmentResponse>, AppError> {
+    debug!("Fetching user enrollments");
+    match fetch_enrollments(state).await {
+        Ok(enrollments) => {
+            debug!("Successfully fetched {} enrollments", enrollments.len());
+            Ok(enrollments)
+        }
+        Err(e) => {
+            error!("Failed to fetch enrollments: {:?}", e);
+            Err(e)
+        }
+    }
 }


### PR DESCRIPTION
## Description

This pull request includes the following changes:

1. **Add 'test' feature to Tauri dependency**: The changes in this commit add the 'test' feature to the Tauri dependency in the Cargo.toml file. This is done to enable testing functionality for the Tauri application.

2. **Add custom datetime serialization and deserialization**: This change adds custom serialization and deserialization for `DateTime<Utc>` types in the `RoadmapEnrollmentResponse` struct. This ensures that the datetime fields are properly formatted and parsed when working with the `education` crate.

3. **Add get_user_enrollments command**: This change adds a new Tauri command `get_user_enrollments` to the `education` crate. The command fetches the user's current roadmap enrollments from the API and returns them as a `Vec<RoadmapEnrollmentResponse>`. This allows the frontend to display the user's enrolled roadmaps.