### PR TITLE
fix: handle gemini errors

### DIFF
--- a/apps/desktop/src/components/ai/ModelSelector.vue
+++ b/apps/desktop/src/components/ai/ModelSelector.vue
@@ -38,6 +38,7 @@ const emit = defineEmits<{
 const open = ref(false)
 const selectedModel = ref(aiModels.find(model => model.value === props.modelValue) || aiModels[0])
 const providerStore = useAIProviderStore();
+const chatStore = useChatStore();
 const handleSelect = (value: string) => {
   const model = aiModels.find(m => m.value === value)
   if (model) {
@@ -61,6 +62,10 @@ const filteredModels = computed(() => {
 const isModelDisabled = (model: AIModel) => {
   const provider = providerStore.getProvider(model.value);
   return provider?.requiresApiKey && !provider?.isConfigured;
+};
+
+const isModelOverloaded = (model: AIModel) => {
+  return model.value === 'gemini' && chatStore.lastError?.includes('sobrecargado');
 };
 </script>
 
@@ -109,6 +114,9 @@ const isModelDisabled = (model: AIModel) => {
                 {{ model.label }}
                 <span v-if="isModelDisabled(model)" class="text-sm text-muted-foreground ml-2">
       (API Key Required)
+    </span>
+                <span v-if="isModelOverloaded(model)" class="text-sm text-yellow-500 ml-2">
+      (Temporalmente Sobrecargado)
     </span>
               </CommandItem>
             </CommandGroup>

--- a/apps/desktop/src/pages/exercises/[id]/solve.vue
+++ b/apps/desktop/src/pages/exercises/[id]/solve.vue
@@ -121,6 +121,7 @@ const panelTabs = computed(() => [
       currentStreamingMessage: chatStore.currentStreamingMessage,
       avatarSrc: authData.value?.avatar_url || "https://placewaifu.com/image",
       isSending: chatStore.isSending,
+      error: chatStore.error
     },
   }
 ])
@@ -179,7 +180,6 @@ watch(selectedModel, async (newModel) => {
   }
 })
 
-// Watch para sincronizar el store con el estado local
 watch(() => codeExecutionStore.activeTab, (newTab) => {
   if (newTab !== currentTab.value) {
     currentTab.value = newTab;


### PR DESCRIPTION
## Description

This pull request includes the following changes:

1. **Handle Gemini API errors and improve usage tracking**:
   - Adds error handling for Gemini API responses, specifically when the `candidatesTokenCount` field is missing from the JSON response.
   - Improves the tracking of token usage by summing the `candidates_token_count` across all response candidates.
   - Updates the `UsageMetadata` struct to include the total candidates token count.

2. **Add error handling and UI improvements to the chat component**:
   - Adds an `isChatBlocked` computed property that checks if the chat is in a state where it should be disabled (e.g., when there's an error, the user is sending a message, or the AI is streaming a response).
   - Modifies the `sendMessage` function to use the `isChatBlocked` computed property to determine if the chat should be disabled.
   - Adds an `Alert` component to display any errors that may occur during the chat session.
   - Updates the input area's background color and opacity based on the chat's state (e.g., disabled when blocked).
   - Adds a disabled state and opacity to the send button when the chat is blocked.
   - Adds an error hint message to inform the user when the chat is blocked due to an error.
   - Updates the `cortexLogo` prop to use the local logo asset instead of a placeholder.

These changes improve the overall user experience by providing better feedback and error handling in the chat component, as well as enhancing the Gemini API integration.