### PR TITLE
feat(api): add forgot and reset password routes

### DIFF
--- a/apps/backend/education/src/main/java/com/cortex/backend/education/roadmap/api/dto/RoadmapCourseDTO.java
+++ b/apps/backend/education/src/main/java/com/cortex/backend/education/roadmap/api/dto/RoadmapCourseDTO.java
@@ -30,4 +30,7 @@ public class RoadmapCourseDTO implements Serializable {
     @JsonProperty("tag_names")
     private List<String> tagNames;
     private List<RoadmapModuleDTO> modules;
+
+    @JsonProperty("display_order")
+    private Integer displayOrder;
 }

--- a/apps/backend/education/src/main/java/com/cortex/backend/education/roadmap/internal/RoadmapMapper.java
+++ b/apps/backend/education/src/main/java/com/cortex/backend/education/roadmap/internal/RoadmapMapper.java
@@ -47,7 +47,8 @@ public interface RoadmapMapper {
   @Mapping(target = "courses", expression = "java(mapCourses(roadmap, userId, userProgressService))")
   @Mapping(target = "tagNames", source = "roadmap.tags", qualifiedByName = "tagsToNamesList")
   @Mapping(target = "isPublished", source = "roadmap.published")
-  RoadmapDetails toRoadmapDetails(Roadmap roadmap, @Context Long userId, @Context UserProgressService userProgressService);
+  RoadmapDetails toRoadmapDetails(Roadmap roadmap, @Context Long userId,
+      @Context UserProgressService userProgressService);
 
   @Named("mediaToUrl")
   default String mediaToUrl(Media media) {
@@ -68,7 +69,8 @@ public interface RoadmapMapper {
         .collect(Collectors.toSet()) : null;
   }
 
-  default List<RoadmapCourseDTO> mapCourses(Roadmap roadmap, Long userId, UserProgressService userProgressService) {
+  default List<RoadmapCourseDTO> mapCourses(Roadmap roadmap, Long userId,
+      UserProgressService userProgressService) {
     return roadmap.getCourses() != null ? roadmap.getCourses().stream()
         .map(course -> new RoadmapCourseDTO(
             course.getId(),
@@ -77,14 +79,16 @@ public interface RoadmapMapper {
             mediaToUrl(course.getImage()),
             course.getSlug(),
             tagsToNamesList(course.getTags()),
-            modulesToDetailedResponses(course.getModuleEntities(), userId, userProgressService)
+            modulesToDetailedResponses(course.getModuleEntities(), userId, userProgressService),
+            course.getDisplayOrder()
         ))
         .toList() : null;
   }
 
 
   @Named("modulesToDetailedResponses")
-  default List<RoadmapModuleDTO> modulesToDetailedResponses(Set<ModuleEntity> modules, Long userId, UserProgressService userProgressService) {
+  default List<RoadmapModuleDTO> modulesToDetailedResponses(Set<ModuleEntity> modules, Long userId,
+      UserProgressService userProgressService) {
     return modules != null ? modules.stream()
         .filter(ModuleEntity::getIsPublished)
         .map(module -> RoadmapModuleDTO.builder()
@@ -100,7 +104,8 @@ public interface RoadmapMapper {
   }
 
   @Named("lessonsToDetailedResponses")
-  default List<RoadmapLessonDTO> lessonsToDetailedResponses(Set<Lesson> lessons, @Context Long userId, @Context UserProgressService userProgressService) {
+  default List<RoadmapLessonDTO> lessonsToDetailedResponses(Set<Lesson> lessons,
+      @Context Long userId, @Context UserProgressService userProgressService) {
     return lessons != null ? lessons.stream()
         .filter(Lesson::getIsPublished)
         .map(lesson -> RoadmapLessonDTO.builder()
@@ -108,21 +113,24 @@ public interface RoadmapMapper {
             .name(lesson.getName())
             .slug(lesson.getSlug())
             .credits(lesson.getCredits())
-            .exercises(exercisesToDetailedResponses(lesson.getExercises(), userId, userProgressService))
+            .exercises(
+                exercisesToDetailedResponses(lesson.getExercises(), userId, userProgressService))
             .displayOrder(lesson.getDisplayOrder())
             .build())
         .toList() : null;
   }
 
   @Named("exercisesToDetailedResponses")
-  default List<RoadmapExerciseDTO> exercisesToDetailedResponses(Set<Exercise> exercises, @Context Long userId, @Context UserProgressService userProgressService) {
+  default List<RoadmapExerciseDTO> exercisesToDetailedResponses(Set<Exercise> exercises,
+      @Context Long userId, @Context UserProgressService userProgressService) {
     return exercises != null ? exercises.stream()
         .map(exercise -> RoadmapExerciseDTO.builder()
             .id(exercise.getId())
             .title(exercise.getTitle())
             .slug(exercise.getSlug())
             .points(exercise.getPoints())
-            .completed(userProgressService.isEntityCompleted(userId, exercise.getId(), EntityType.EXERCISE))
+            .completed(userProgressService.isEntityCompleted(userId, exercise.getId(),
+                EntityType.EXERCISE))
             .displayOrder(exercise.getDisplayOrder())
             .build())
         .toList() : null;

--- a/apps/frontend/src/pages/reset-password.vue
+++ b/apps/frontend/src/pages/reset-password.vue
@@ -1,0 +1,139 @@
+<script setup lang="ts">
+import { toTypedSchema } from '@vee-validate/zod'
+import * as z from 'zod'
+import { Loader2 } from 'lucide-vue-next'
+import { API_ROUTES } from "@cortex/shared/config/api"
+
+definePageMeta({
+  layout: 'auth-default',
+  auth: {
+    unauthenticatedOnly: true,
+    navigateAuthenticatedTo: '/explore'
+  },
+})
+
+const route = useRoute()
+const router = useRouter()
+const { handleError } = useWebErrorHandler()
+const isSuccessDialogOpen = ref(false)
+const isSubmitting = ref(false)
+
+const token = route.query.token as string
+if (!token) {
+  router.push('/login')
+}
+
+const resetPasswordSchema = toTypedSchema(
+    z.object({
+      new_password: z
+      .string()
+      .min(8, 'La contraseña debe tener al menos 8 caracteres')
+      .regex(
+          /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]/,
+          'La contraseña debe contener al menos una letra mayúscula, una minúscula, un número y un carácter especial'
+      ),
+      confirm_password: z.string().min(1, 'Confirma tu contraseña'),
+    }).refine((data) => data.new_password === data.confirm_password, {
+      message: "Las contraseñas no coinciden",
+      path: ["confirm_password"],
+    })
+)
+
+const form = useForm({
+  validationSchema: resetPasswordSchema,
+})
+
+const onSubmit = form.handleSubmit(async (values) => {
+  try {
+    isSubmitting.value = true
+    await $fetch(API_ROUTES.RESET_PASSWORD, {
+      method: 'POST',
+      body: {
+        token,
+        new_password: values.new_password
+      }
+    })
+
+    isSuccessDialogOpen.value = true
+    setTimeout(() => {
+      router.push('/auth/login')
+    }, 3000)
+
+  } catch (error) {
+    await handleError(error)
+  } finally {
+    isSubmitting.value = false
+  }
+})
+</script>
+
+<template>
+  <Card class="mx-auto max-w-md space-y-6 p-6 w-full bg-white bg-opacity-20 backdrop-blur-lg rounded-xl shadow-lg">
+    <div class="space-y-2 text-center">
+      <h1 class="text-2xl font-bold">Resetear Contraseña</h1>
+      <p class="text-gray-500 dark:text-gray-400">
+        Ingresa tu nueva contraseña
+      </p>
+    </div>
+
+    <form @submit="onSubmit" class="space-y-4">
+      <FormField
+          v-slot="{ componentField }"
+          name="new_password"
+      >
+        <FormItem>
+          <FormLabel>Nueva Contraseña</FormLabel>
+          <FormControl>
+            <Input
+                type="password"
+                placeholder="********"
+                v-bind="componentField"
+            />
+          </FormControl>
+          <FormMessage />
+        </FormItem>
+      </FormField>
+
+      <FormField
+          v-slot="{ componentField }"
+          name="confirm_password"
+      >
+        <FormItem>
+          <FormLabel>Confirmar Contraseña</FormLabel>
+          <FormControl>
+            <Input
+                type="password"
+                placeholder="********"
+                v-bind="componentField"
+            />
+          </FormControl>
+          <FormMessage />
+        </FormItem>
+      </FormField>
+
+      <Button
+          type="submit"
+          class="w-full"
+          :disabled="isSubmitting"
+      >
+        <Loader2
+            v-if="isSubmitting"
+            class="mr-2 h-4 w-4 animate-spin"
+        />
+        Cambiar Contraseña
+      </Button>
+    </form>
+  </Card>
+
+  <!-- Diálogo de éxito -->
+  <Dialog :open="isSuccessDialogOpen" @update:open="isSuccessDialogOpen = $event">
+    <DialogContent>
+      <DialogHeader>
+        <DialogTitle>¡Contraseña actualizada!</DialogTitle>
+        <DialogDescription>
+          Tu contraseña ha sido actualizada exitosamente. Serás redirigido al inicio de sesión en unos segundos.
+        </DialogDescription>
+      </DialogHeader>
+    </DialogContent>
+  </Dialog>
+</template>

--- a/packages/shared/config/api.ts
+++ b/packages/shared/config/api.ts
@@ -12,5 +12,7 @@ export const API_ROUTES = {
   LESSONS: `${API_BASE_URL}/education/lesson`,
   EXERCISES: `${API_BASE_URL}/exercises`,
   USER: `${API_BASE_URL}/user`,
-  CHANGE_PASSWORD: `${API_BASE_URL}/user/change-password`
+  CHANGE_PASSWORD: `${API_BASE_URL}/user/change-password`,
+  FORGOT_PASSWORD: `${API_BASE_URL}/auth/forgot-password`,
+  RESET_PASSWORD: `${API_BASE_URL}/auth/reset-password`,
 }


### PR DESCRIPTION
The changes in this commit add two new API routes to the `API_ROUTES` object:

1. `FORGOT_PASSWORD`: `${API_BASE_URL}/auth/forgot-password`
2. `RESET_PASSWORD`: `${API_BASE_URL}/auth/reset-password`

These routes are added to support the functionality of password reset and password recovery for the application.

feat(roadmap): add display order to roadmap course

This commit adds a new property `displayOrder` to the `RoadmapCourseDTO` class. This property will be used to determine the order in which the courses are displayed in the roadmap.

The `RoadmapMapper` interface is also updated to include the `displayOrder` property when mapping the `RoadmapCourseDTO` objects.