### PR TITLE
feat(pages): add auth metadata to about page and update login redirect

### DIFF
--- a/apps/frontend/src/pages/about.vue
+++ b/apps/frontend/src/pages/about.vue
@@ -4,6 +4,10 @@ import xdImage from '~/assets/img/xd.webp'
 import cinnamorollImage from '~/assets/img/cinnamoroll.webp'
 import godImage from '~/assets/img/god.webp'
 
+definePageMeta({
+  auth: false
+})
+
 const testimonios = [
   {
     nombre: "Vicente Zapata",

--- a/apps/frontend/src/pages/auth/login.vue
+++ b/apps/frontend/src/pages/auth/login.vue
@@ -11,7 +11,7 @@ definePageMeta({
   layout: 'auth-default',
   auth: {
     unauthenticatedOnly: true,
-    navigateAuthenticatedTo: '/roadmaps'
+    navigateAuthenticatedTo: '/explore'
   },
 })
 


### PR DESCRIPTION
The changes made in this commit include:

1. Adding `definePageMeta` to the `about.vue` file, which sets the `auth` property to `false`. This ensures that the about page is accessible to both authenticated and unauthenticated users.

2. Updating the `navigateAuthenticatedTo` property in the `login.vue` file from `/roadmaps` to `/explore`. This change ensures that authenticated users are redirected to the `/explore` page after successful login, instead of the `/roadmaps` page.