### PR TITLE
feat(roadmap): Add mentor details to roadmap response

### DIFF
--- a/apps/backend/education/src/main/java/com/cortex/backend/education/roadmap/api/RoadmapRepository.java
+++ b/apps/backend/education/src/main/java/com/cortex/backend/education/roadmap/api/RoadmapRepository.java
@@ -13,13 +13,13 @@ import org.springframework.stereotype.Repository;
 public interface RoadmapRepository extends CrudRepository<Roadmap, Long> {
 
   Optional<Roadmap> findBySlug(String slug);
-  
+
   Boolean existsBySlug(String slug);
 
   @Query("""
-      SELECT  rodmap
-      FROM Roadmap rodmap
-      WHERE rodmap.isPublished = true
+      SELECT DISTINCT r
+      FROM Roadmap r
+      WHERE r.isPublished = true
       """)
   Page<Roadmap> findAllPublishedRoadmaps(Pageable pageable);
 
@@ -36,12 +36,12 @@ public interface RoadmapRepository extends CrudRepository<Roadmap, Long> {
   Optional<Roadmap> findBySlugWithDetails(@Param("slug") String slug);
 
   @Query("""
-    SELECT DISTINCT r FROM Roadmap r
-    LEFT JOIN FETCH r.courses c
-    LEFT JOIN FETCH c.moduleEntities m
-    LEFT JOIN FETCH m.lessons l
-    LEFT JOIN FETCH l.exercises e
-    WHERE r.slug = :slug
-    """)
+      SELECT DISTINCT r FROM Roadmap r
+      LEFT JOIN FETCH r.courses c
+      LEFT JOIN FETCH c.moduleEntities m
+      LEFT JOIN FETCH m.lessons l
+      LEFT JOIN FETCH l.exercises e
+      WHERE r.slug = :slug
+      """)
   Optional<Roadmap> findBySlugWithDetailsWithAdminRole(@Param("slug") String slug);
 }

--- a/apps/backend/education/src/main/java/com/cortex/backend/education/roadmap/api/dto/RoadmapDetails.java
+++ b/apps/backend/education/src/main/java/com/cortex/backend/education/roadmap/api/dto/RoadmapDetails.java
@@ -33,6 +33,9 @@ public class RoadmapDetails implements Serializable {
 
     private List<RoadmapCourseDTO> courses;
 
+    @JsonProperty("mentor")
+    private RoadmapMentorDTO mentor;
+
     @JsonProperty("is_published")
     private boolean isPublished;
 

--- a/apps/backend/education/src/main/java/com/cortex/backend/education/roadmap/api/dto/RoadmapMentorDTO.java
+++ b/apps/backend/education/src/main/java/com/cortex/backend/education/roadmap/api/dto/RoadmapMentorDTO.java
@@ -1,0 +1,18 @@
+package com.cortex.backend.education.roadmap.api.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.io.Serializable;
+import lombok.Builder;
+import lombok.Value;
+
+@Value
+@Builder
+public class RoadmapMentorDTO implements Serializable {
+  @JsonProperty("full_name")
+  String fullName;
+
+  String username;
+
+  @JsonProperty("avatar_url")
+  String avatarUrl;
+}

--- a/apps/backend/education/src/main/java/com/cortex/backend/education/roadmap/internal/RoadmapServiceImpl.java
+++ b/apps/backend/education/src/main/java/com/cortex/backend/education/roadmap/internal/RoadmapServiceImpl.java
@@ -27,6 +27,7 @@ import com.cortex.backend.education.roadmap.api.dto.RoadmapResponse;
 import com.cortex.backend.education.roadmap.api.dto.RoadmapUpdateRequest;
 import com.cortex.backend.education.tags.internal.TagService;
 import com.cortex.backend.media.api.MediaService;
+import com.cortex.backend.user.repository.UserRepository;
 import jakarta.persistence.EntityNotFoundException;
 import java.io.IOException;
 import java.util.HashSet;
@@ -57,6 +58,7 @@ import org.springframework.web.multipart.MultipartFile;
 public class RoadmapServiceImpl implements RoadmapService {
 
   private final RoadmapRepository roadmapRepository;
+  private final UserRepository userRepository;
   private final RoadmapMapper roadmapMapper;
   private final MediaService mediaService;
   private final SlugUtils slugUtils;
@@ -113,11 +115,11 @@ public class RoadmapServiceImpl implements RoadmapService {
     if (user.hasAnyRole("ADMIN", "MODERATOR")) {
       return roadmapRepository.findBySlugWithDetailsWithAdminRole(slug)
           .map(roadmap -> roadmapMapper.toRoadmapDetails(roadmap, user.getId(),
-              userProgressService));
+              userProgressService,userRepository));
     }
 
     return roadmapRepository.findBySlugWithDetails(slug)
-        .map(roadmap -> roadmapMapper.toRoadmapDetails(roadmap, user.getId(), userProgressService));
+        .map(roadmap -> roadmapMapper.toRoadmapDetails(roadmap, user.getId(), userProgressService, userRepository));
   }
 
   @Override


### PR DESCRIPTION
This change adds the ability to retrieve mentor details for a roadmap. The
RoadmapMapper now includes a new method `userToMentorDto` that maps a user
entity to a RoadmapMentorDTO. This DTO contains the mentor's full name,
username, and avatar URL.

The RoadmapServiceImpl has been updated to pass the UserRepository to the
RoadmapMapper when retrieving the roadmap details, allowing the mapper to
fetch the mentor information.

Additionally, the RoadmapRepository has been updated to use a more readable
query for fetching the roadmap details with the admin role.