### PR TITLE
add-mentor-details-to-roadmap-overview

### DIFF
--- a/apps/desktop/src-tauri/crates/education/src/lib.rs
+++ b/apps/desktop/src-tauri/crates/education/src/lib.rs
@@ -255,8 +255,16 @@ pub struct RoadmapCourse {
     #[serde(rename = "tag_names")]
     pub tag_names: Vec<String>,
     pub modules: Vec<RoadmapModule>,
-    // pub display_order: i32,
+    pub display_order: i32,
 }
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct RoadmapMentor {
+    pub full_name: String,
+    pub username: String,
+    pub avatar_url: Option<String>,
+}
+
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct RoadmapDetails {
@@ -271,6 +279,7 @@ pub struct RoadmapDetails {
     #[serde(rename = "is_published")]
     pub is_published: bool,
     pub courses: Vec<RoadmapCourse>,
+    pub mentor: RoadmapMentor,
     #[serde(rename = "created_at")]
     pub created_at: String,
     #[serde(rename = "updated_at")]

--- a/apps/desktop/src/composables/useRoadmaps.ts
+++ b/apps/desktop/src/composables/useRoadmaps.ts
@@ -246,6 +246,7 @@ export function useRoadmaps() {
     createRoadmap,
     updateRoadmap,
     transformFormToRequest,
-    deleteRoadmap
+    deleteRoadmap,
+    enrollments
   }
 }

--- a/apps/desktop/src/pages/explore/[slug]/index.vue
+++ b/apps/desktop/src/pages/explore/[slug]/index.vue
@@ -55,6 +55,7 @@ const credits = computed(() => {
           :description="roadmap.description"
           :created-at="roadmap.created_at"
           :updated-at="roadmap.updated_at"
+          :mentor="roadmap.mentor"
         />
         <RoadmapInscriptionCard
           :roadmap="roadmap"/>

--- a/packages/shared/components/roadmaps/RoadmapOverview.vue
+++ b/packages/shared/components/roadmaps/RoadmapOverview.vue
@@ -7,7 +7,7 @@ import InstagramIcon from '@cortex/shared/components/icons/InstagramIcon.vue';
 import TwitterIcon from '@cortex/shared/components/icons/TwitterIcon.vue';
 import LinkedinIcon from '@cortex/shared/components/icons/LinkedinIcon.vue';
 import GithubIcon from '@cortex/shared/components/icons/GithubIcon.vue';
-import { RoadmapMentor } from '@cortex/shared/types';
+import type { RoadmapMentor } from '@cortex/shared/types';
 
 export interface RoadmapOverviewProps {
   description: string
@@ -107,8 +107,8 @@ const initials = computed(() => {
         <div class="flex-col flex justify-between gap-3 text-sm w-3/4">
           <div class="flex items-center gap-3">
             <Avatar class="w-12 h-12">
-              <AvatarImage 
-                v-if="mentor.avatar_url" 
+              <AvatarImage
+                v-if="mentor.avatar_url"
                 :src="mentor.avatar_url"
                 :alt="mentor.username || ''"
               />


### PR DESCRIPTION
**Pull Request Description:**

This pull request adds mentor details to the roadmap overview in the application. The changes include:

1. Exporting the `enrollments` function from the `useRoadmaps` composable, which allows it to be used in other parts of the application when working with roadmaps.

2. Displaying the mentor information, including the full name, username, and avatar image, on the roadmap card in the explore page. This provides users with more detailed information about the roadmap they are viewing.

3. Adding the mentor details to the roadmap overview component, which now displays the mentor's full name, username, and avatar image to provide more context about the roadmap's mentor.

These changes enhance the user experience by giving users more information about the roadmaps they are exploring and the mentors behind them.