### PR TITLE
🔒 feat(auth): Simplify account activation endpoint

### DIFF
--- a/apps/frontend/src/stores/auth.store.ts
+++ b/apps/frontend/src/stores/auth.store.ts
@@ -47,7 +47,7 @@ export const useAuthStore = defineStore('auth', () => {
         })
       }
 
-      await $fetch(`${API_ROUTES.ACTIVATE_ACCOUNT}/auth/activate-account`, {
+      await $fetch(`${API_ROUTES.ACTIVATE_ACCOUNT}`, {
         method: 'GET',
         params: { token }
       })


### PR DESCRIPTION
Simplify the account activation endpoint by removing the
unnecessary "/auth" segment from the URL. This change makes
the endpoint more concise and easier to maintain.