### PR TITLE
🔖 feat(version): Bump version to 0.1.7

### DIFF
--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cortex"
-version = "0.1.6"
+version = "0.1.7"
 description = "Cortex Desktop Application for Premium Users"
 authors = ["Bytech SpA"]
 license = "AGPL-3"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Cortex",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "identifier": "com.cortex.app",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
Bumps the version number in the `tauri.conf.json` and `Cargo.toml` files
from 0.1.6 to 0.1.7. This change is necessary to reflect the latest
version of the Cortex Desktop Application for Premium Users.