### PR TITLE
🎨 feat(admin/roadmaps): improve loading state handling

### DIFF
--- a/apps/desktop/src/pages/admin/roadmaps/[slug].vue
+++ b/apps/desktop/src/pages/admin/roadmaps/[slug].vue
@@ -52,7 +52,7 @@ const loadRoadmap = async () => {
       await router.push('/admin/roadmaps/create');
     }
   } finally {
-    isLoading.value = false;
+    isLoading.value = isCreateMode.value ? false : loading.value;
   }
 };
 
@@ -150,7 +150,7 @@ await loadRoadmap();
       :icon-component="RoadmapIcon"
       :submit-label="isCreateMode ? 'Crear Roadmap' : 'Actualizar Roadmap'"
       :initial-values="initialValues"
-      :is-loading="loading"
+      :is-loading="isCreateMode ? false : loading"
       @submit="handleSubmit"
     />
   </div>


### PR DESCRIPTION
Improves the loading state handling in the admin roadmaps page. When the
page is in create mode, the loading state is set to false to avoid
showing a loading spinner. When the page is in edit mode, the loading
state is set to the value of the `loading` variable.