### PR TITLE
✨ feat(license): add license activation, validation, and deactivation

### DIFF
--- a/apps/backend/core/src/main/java/com/cortex/backend/core/common/BusinessErrorCodes.java
+++ b/apps/backend/core/src/main/java/com/cortex/backend/core/common/BusinessErrorCodes.java
@@ -51,6 +51,9 @@ public enum BusinessErrorCodes {
   ALREADY_ENROLLED(328, BAD_REQUEST, "User already enrolled in this roadmap"),
   EXERCISE_NOT_PUBLISHED(330, BAD_REQUEST, "Exercise is not published"),
   EXERCISE_NO_LESSON(331, BAD_REQUEST, "Exercise has no lesson assigned"),
+  FAILED_TO_ACTIVATE_LICENSE(332, INTERNAL_SERVER_ERROR, "Failed to activate license, please try again"),
+  FAILED_TO_VALIDATE_LICENSE(332, INTERNAL_SERVER_ERROR, "Failed validate license, please try again"),
+  FAILED_TO_DEACTIVATE_LICENSE(332, INTERNAL_SERVER_ERROR, "Failed deactivate license, please try again"),
   ;
   private final int code;
   private final String description;

--- a/apps/backend/core/src/main/java/com/cortex/backend/core/common/exception/FailedToActivateLicenseException.java
+++ b/apps/backend/core/src/main/java/com/cortex/backend/core/common/exception/FailedToActivateLicenseException.java
@@ -1,0 +1,10 @@
+package com.cortex.backend.core.common.exception;
+
+public class FailedToActivateLicenseException extends RuntimeException {
+
+
+
+  public FailedToActivateLicenseException(String message) {
+    super(message);
+  }
+}

--- a/apps/backend/core/src/main/java/com/cortex/backend/core/common/exception/FailedToDeactivateLicenseException.java
+++ b/apps/backend/core/src/main/java/com/cortex/backend/core/common/exception/FailedToDeactivateLicenseException.java
@@ -1,0 +1,8 @@
+package com.cortex.backend.core.common.exception;
+
+public class FailedToDeactivateLicenseException extends RuntimeException {
+
+  public FailedToDeactivateLicenseException(String message) {
+    super(message);
+  }
+}

--- a/apps/backend/core/src/main/java/com/cortex/backend/core/common/exception/FailedToValidateLicenseException.java
+++ b/apps/backend/core/src/main/java/com/cortex/backend/core/common/exception/FailedToValidateLicenseException.java
@@ -1,0 +1,8 @@
+package com.cortex.backend.core.common.exception;
+
+public class FailedToValidateLicenseException extends RuntimeException {
+
+  public FailedToValidateLicenseException(String message) {
+    super(message);
+  }
+}

--- a/apps/backend/core/src/main/java/com/cortex/backend/core/handler/GlobalExceptionHandler.java
+++ b/apps/backend/core/src/main/java/com/cortex/backend/core/handler/GlobalExceptionHandler.java
@@ -45,6 +45,9 @@ import com.cortex.backend.core.common.exception.EmailSendingException;
 import com.cortex.backend.core.common.exception.ExerciseCreationException;
 import com.cortex.backend.core.common.exception.ExerciseReadException;
 import com.cortex.backend.core.common.exception.ExpiredTokenException;
+import com.cortex.backend.core.common.exception.FailedToActivateLicenseException;
+import com.cortex.backend.core.common.exception.FailedToDeactivateLicenseException;
+import com.cortex.backend.core.common.exception.FailedToValidateLicenseException;
 import com.cortex.backend.core.common.exception.FileSizeExceededException;
 import com.cortex.backend.core.common.exception.GitSyncException;
 import com.cortex.backend.core.common.exception.HashGenerationException;
@@ -477,6 +480,43 @@ public class GlobalExceptionHandler {
             .build());
   }
 
+  @ExceptionHandler(FailedToActivateLicenseException.class)
+  public ResponseEntity<ExceptionResponse> handleFailedToActivateLicenseException(
+      FailedToActivateLicenseException exp) {
+    return ResponseEntity.status(BusinessErrorCodes.FAILED_TO_ACTIVATE_LICENSE.getHttpStatus())
+        .body(
+            ExceptionResponse.builder()
+                .code(BusinessErrorCodes.FAILED_TO_ACTIVATE_LICENSE.getCode())
+                .description(BusinessErrorCodes.FAILED_TO_ACTIVATE_LICENSE.getDescription())
+                .error(exp.getMessage())
+                .build());
+  }
+
+
+  @ExceptionHandler(FailedToValidateLicenseException.class)
+  public ResponseEntity<ExceptionResponse> handleFailedToValidateLicenseException(
+      FailedToValidateLicenseException exp) {
+    return ResponseEntity.status(BusinessErrorCodes.FAILED_TO_VALIDATE_LICENSE.getHttpStatus())
+        .body(
+            ExceptionResponse.builder()
+                .code(BusinessErrorCodes.FAILED_TO_VALIDATE_LICENSE.getCode())
+                .description(BusinessErrorCodes.FAILED_TO_VALIDATE_LICENSE.getDescription())
+                .error(exp.getMessage())
+                .build());
+  }
+
+
+  @ExceptionHandler(FailedToDeactivateLicenseException.class)
+  public ResponseEntity<ExceptionResponse> handleFailedToDeactivateLicenseException(
+      FailedToDeactivateLicenseException exp) {
+    return ResponseEntity.status(BusinessErrorCodes.FAILED_TO_DEACTIVATE_LICENSE.getHttpStatus())
+        .body(
+            ExceptionResponse.builder()
+                .code(BusinessErrorCodes.FAILED_TO_DEACTIVATE_LICENSE.getCode())
+                .description(BusinessErrorCodes.FAILED_TO_DEACTIVATE_LICENSE.getDescription())
+                .error(exp.getMessage())
+                .build());
+  }
 
   @ExceptionHandler(Exception.class)
   public ResponseEntity<ExceptionResponse> handleException(Exception exp) {

--- a/apps/backend/payments/src/main/java/com/cortex/backend/payments/api/SubscriptionsController.java
+++ b/apps/backend/payments/src/main/java/com/cortex/backend/payments/api/SubscriptionsController.java
@@ -1,0 +1,82 @@
+package com.cortex.backend.payments.api;
+
+import com.cortex.backend.lemonsqueezy.licensekeys.dto.LicenseActivationResponse;
+import com.cortex.backend.lemonsqueezy.licensekeys.dto.LicenseDeactivationResponse;
+import com.cortex.backend.lemonsqueezy.licensekeys.dto.LicenseValidationResponse;
+import com.cortex.backend.payments.internal.PaymentsService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/subscriptions")
+@Tag(name = "Subscriptions", description = "API endpoints for managing license subscriptions")
+public class SubscriptionsController {
+
+  private final PaymentsService paymentsService;
+
+  @Operation(summary = "Validate a license key",
+      description = "Validates a license key with its corresponding instance ID")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "License validated successfully"),
+      @ApiResponse(responseCode = "400", description = "Invalid license key or instance ID"),
+      @ApiResponse(responseCode = "500", description = "Failed to validate license")
+  })
+  @GetMapping("/validate")
+  public ResponseEntity<LicenseValidationResponse> validateLicense(
+      @Parameter(description = "License key to validate", required = true)
+      @RequestParam("license_key") String licenseKey,
+      @Parameter(description = "Instance ID associated with the license", required = true)
+      @RequestParam("instance_id") String instanceId) {
+
+    LicenseValidationResponse response = paymentsService.validateLicense(licenseKey, instanceId);
+    return ResponseEntity.ok(response);
+  }
+
+  @Operation(summary = "Activate a license key",
+      description = "Activates a license key for a specific instance")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "License activated successfully"),
+      @ApiResponse(responseCode = "400", description = "Invalid license key or instance name"),
+      @ApiResponse(responseCode = "500", description = "Failed to activate license")
+  })
+  @PostMapping("/activate")
+  public ResponseEntity<LicenseActivationResponse> activateLicense(
+      @Parameter(description = "License key to activate", required = true)
+      @RequestParam("license_key") String licenseKey,
+      @Parameter(description = "Name of the instance to activate", required = true)
+      @RequestParam("instance_name") String instanceName) {
+
+    LicenseActivationResponse response = paymentsService.activateLicense(licenseKey, instanceName);
+    return ResponseEntity.ok(response);
+  }
+
+  @Operation(summary = "Deactivate a license key",
+      description = "Deactivates a license key for a specific instance")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "License deactivated successfully"),
+      @ApiResponse(responseCode = "400", description = "Invalid license key or instance ID"),
+      @ApiResponse(responseCode = "500", description = "Failed to deactivate license")
+  })
+  @DeleteMapping("/deactivate")
+  public ResponseEntity<LicenseDeactivationResponse> deactivateLicense(
+      @Parameter(description = "License key to deactivate", required = true)
+      @RequestParam("license_key") String licenseKey,
+      @Parameter(description = "Instance ID to deactivate", required = true)
+      @RequestParam("instance_id") String instanceId) {
+
+    LicenseDeactivationResponse response = paymentsService.deactivateLicense(licenseKey, instanceId);
+    return ResponseEntity.ok(response);
+  }
+}

--- a/apps/backend/payments/src/main/java/com/cortex/backend/payments/internal/PaymentsService.java
+++ b/apps/backend/payments/src/main/java/com/cortex/backend/payments/internal/PaymentsService.java
@@ -1,0 +1,52 @@
+package com.cortex.backend.payments.internal;
+
+import com.cortex.backend.core.common.exception.FailedToActivateLicenseException;
+import com.cortex.backend.core.common.exception.FailedToDeactivateLicenseException;
+import com.cortex.backend.core.common.exception.FailedToValidateLicenseException;
+import com.cortex.backend.lemonsqueezy.licensekeys.LicenseKeyService;
+import com.cortex.backend.lemonsqueezy.licensekeys.dto.LicenseActivationResponse;
+import com.cortex.backend.lemonsqueezy.licensekeys.dto.LicenseDeactivationResponse;
+import com.cortex.backend.lemonsqueezy.licensekeys.dto.LicenseValidationResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class PaymentsService {
+
+  private final LicenseKeyService licenseKeyService;
+
+  public LicenseActivationResponse activateLicense(String licenseKey, String instanceName) {
+    try {
+      log.info("Activating license key: {}", licenseKey);
+      return licenseKeyService.activateLicenseKey(licenseKey, instanceName);
+    } catch (IOException e) {
+      log.error("Error activating license key: {}", e.getMessage());
+      throw new FailedToActivateLicenseException(e.getMessage());
+    }
+  }
+
+  public LicenseDeactivationResponse deactivateLicense(String licenseKey, String instanceId) {
+    try {
+      log.info("Deactivating license key: {}", licenseKey);
+      return licenseKeyService.deactivateLicenseKey(licenseKey, instanceId);
+    } catch (IOException e) {
+      log.error("Error deactivating license key: {}", e.getMessage());
+      throw new FailedToDeactivateLicenseException(e.getMessage());
+    }
+  }
+
+
+  public LicenseValidationResponse validateLicense(String licenseKey, String instanceId) {
+    try {
+      log.info("Validating license key: {}", licenseKey);
+      return licenseKeyService.validateLicenseKey(licenseKey, instanceId);
+    } catch (IOException e) {
+      log.error("Error validating license key: {}", e.getMessage());
+      throw new FailedToValidateLicenseException(e.getMessage());
+    }
+  }
+}

--- a/bruno/Payments/Deactivate License Key.bru
+++ b/bruno/Payments/Deactivate License Key.bru
@@ -4,7 +4,7 @@ meta {
   seq: 2
 }
 
-post {
+delete {
   url: {{BASEURL}}/api/v1/subscriptions/deactivate?license_key=196F3391-6889-46AB-8269-A9F3A34DA64E&instance_id=a6635d61-3fcc-40ec-af4e-d0d4ed09ecf4
   body: none
   auth: bearer

--- a/bruno/Payments/Validate License Key.bru
+++ b/bruno/Payments/Validate License Key.bru
@@ -4,7 +4,7 @@ meta {
   seq: 3
 }
 
-post {
+get {
   url: {{BASEURL}}/api/v1/subscriptions/validate?license_key=196F3391-6889-46AB-8269-A9F3A34DA64E&instance_id=ca13e341-ba48-4ac6-8fd0-b190789a4e8a
   body: none
   auth: bearer


### PR DESCRIPTION
Adds new exceptions and error codes for handling license-related operations:

- `FailedToActivateLicenseException`
- `FailedToValidateLicenseException`
- `FailedToDeactivateLicenseException`

These exceptions are used in the `PaymentsService` to handle failures during license activation, validation, and deactivation.

The `GlobalExceptionHandler` is updated to handle these new exceptions and provide appropriate HTTP responses.