### PR TITLE
✨ feat(lesson): Add endpoint to get lessons by module

### DIFF
--- a/apps/backend/education/src/main/java/com/cortex/backend/education/lesson/api/LessonController.java
+++ b/apps/backend/education/src/main/java/com/cortex/backend/education/lesson/api/LessonController.java
@@ -93,6 +93,22 @@ public class LessonController {
         .orElse(ResponseEntity.notFound().build());
   }
 
+  @GetMapping("/module")
+  @Operation(summary = "Get a lesson by module ID", description = "Retrieves a lesson by its module ID")
+  @ApiResponse(responseCode = "200", description = "Successful operation",
+      content = @Content(schema = @Schema(implementation = LessonResponse.class)))
+  @ApiResponse(responseCode = "404", description = "Lesson not found")
+  public ResponseEntity<PageResponse<LessonResponse>> getLessonByModuleId(
+      @RequestParam(name = "id") Long moduleID,
+      @RequestParam(name = "page", defaultValue = "0") int page,
+      @RequestParam(name = "size", defaultValue = "10") int size,
+      @RequestParam(name = "sort", required = false) String[] sort,
+      Authentication authentication
+  ) {
+    Long userId = authentication != null ? ((User) authentication.getPrincipal()).getId() : null;
+    return ResponseEntity.ok(lessonService.getLessonsByModule(moduleID, page, size, sort, userId));
+  }
+
 
   @PostMapping
   @PreAuthorize("hasAnyRole('MODERATOR', 'ADMIN')")

--- a/apps/backend/education/src/main/java/com/cortex/backend/education/lesson/api/LessonRepository.java
+++ b/apps/backend/education/src/main/java/com/cortex/backend/education/lesson/api/LessonRepository.java
@@ -35,4 +35,11 @@ public interface LessonRepository extends CrudRepository<Lesson, Long> {
   Page<Lesson> findAllPublishedLessons(Pageable pageable);
 
   Page<Lesson> findAll(Pageable pageable);
+
+  @Query("""
+      SELECT  lesson
+      FROM Lesson lesson
+      WHERE lesson.moduleEntity.id = :moduleID
+      """)
+  Page<Lesson> findAllByModule(Long moduleID, Pageable pageable);
 }

--- a/apps/backend/education/src/main/java/com/cortex/backend/education/lesson/api/LessonService.java
+++ b/apps/backend/education/src/main/java/com/cortex/backend/education/lesson/api/LessonService.java
@@ -5,7 +5,6 @@ import com.cortex.backend.education.lesson.api.dto.LessonRequest;
 import com.cortex.backend.education.lesson.api.dto.LessonResponse;
 import com.cortex.backend.education.lesson.api.dto.LessonUpdateRequest;
 import java.util.Optional;
-import org.springframework.data.domain.Page;
 
 public interface LessonService {
 
@@ -17,6 +16,8 @@ public interface LessonService {
   Optional<LessonResponse> getLessonById(Long id, Long userId);
 
   Optional<LessonResponse> getLessonBySlug(String slug, Long userId);
+
+  PageResponse<LessonResponse> getLessonsByModule(Long moduleID, int page, int size, String[] sort, Long userId);
 
   LessonResponse createLesson(LessonRequest request);
 

--- a/apps/backend/education/src/main/java/com/cortex/backend/education/lesson/internal/LessonServiceImpl.java
+++ b/apps/backend/education/src/main/java/com/cortex/backend/education/lesson/internal/LessonServiceImpl.java
@@ -42,7 +42,8 @@ public class LessonServiceImpl implements LessonService {
 
   @Override
   @Transactional(readOnly = true)
-  public PageResponse<LessonResponse> getAllPublishedLessons(int page, int size, String[] sort, Long userId) {
+  public PageResponse<LessonResponse> getAllPublishedLessons(int page, int size, String[] sort,
+      Long userId) {
     Sort sortBy = SortUtils.parseSort(sort);
     Pageable pageable = PageRequest.of(page, size, sortBy);
 
@@ -58,7 +59,8 @@ public class LessonServiceImpl implements LessonService {
 
   @Override
   @Transactional(readOnly = true)
-  public PageResponse<LessonResponse> getAllLessons(int page, int size, String[] sort, Long userId) {
+  public PageResponse<LessonResponse> getAllLessons(int page, int size, String[] sort,
+      Long userId) {
     Sort sortBy = SortUtils.parseSort(sort);
     Pageable pageable = PageRequest.of(page, size, sortBy);
 
@@ -84,6 +86,24 @@ public class LessonServiceImpl implements LessonService {
   public Optional<LessonResponse> getLessonBySlug(String slug, Long userId) {
     return lessonRepository.findBySlug(slug)
         .map(lesson -> lessonMapper.toLessonResponse(lesson, userId, userProgressService));
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public PageResponse<LessonResponse> getLessonsByModule(Long moduleID, int page, int size,
+      String[] sort, Long userId) {
+    Sort sortBy = SortUtils.parseSort(sort);
+    Pageable pageable = PageRequest.of(page, size, sortBy);
+
+    Page<Lesson> lessons = lessonRepository.findAllByModule(moduleID, pageable);
+
+    List<LessonResponse> response = lessons.stream()
+        .map(lesson -> lessonMapper.toLessonResponse(lesson, userId, userProgressService))
+        .toList();
+
+    return new PageResponse<>(response, lessons.getNumber(), lessons.getSize(),
+        lessons.getTotalElements(), lessons.getTotalPages(), lessons.isFirst(), lessons.isLast());
+
   }
 
   @Override

--- a/bruno/Education/Lesson/Get Lesson By Module.bru
+++ b/bruno/Education/Lesson/Get Lesson By Module.bru
@@ -1,0 +1,20 @@
+meta {
+  name: Get Lesson By Module
+  type: http
+  seq: 8
+}
+
+get {
+  url: {{BASEURL}}/api/v1/education/lesson/module?id=1&sort=name:asc,createdAt:desc
+  body: none
+  auth: bearer
+}
+
+params:query {
+  id: 1
+  sort: name:asc,createdAt:desc
+}
+
+auth:bearer {
+  token: {{token}}
+}


### PR DESCRIPTION
This change adds a new endpoint to the LessonController that allows retrieving lessons by a given module ID. The LessonService and LessonRepository have been updated to support this new functionality.

The main changes are:

- Added a new `getLessonsByModule` method in the LessonService interface and its implementation in LessonServiceImpl.
- Added a new `findAllByModule` method in the LessonRepository to fetch lessons by module ID.
- Added a new `getLessonByModuleId` endpoint in the LessonController to handle the new functionality.